### PR TITLE
Updates on product com section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You should now see a message similar to:
 
 Point your browser at that URL, and you'll get real time updates to the generated documentation as you edit.
 
+mkdocs has its own formatting syntax, to get started look [here](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) for an excellent cheatsheet
 
 ### Updating the site
 

--- a/docs/committee.md
+++ b/docs/committee.md
@@ -4,7 +4,7 @@
 
 ## Admin Committee
 
-
+---
 ## Product Committee
 
 ### Charter
@@ -39,7 +39,7 @@ The PC shall work with other PeeringDB committees to ensure an equitable divisio
 
 #### Participation
 
-The PeeringDB Product Committee members serve a 1 year renewable term. Volunteers can submit their candidacy to the PeeringDB Board. The Board will elect a new Product Committee after the Board election or at any time the Board sees the necessity to ensure the continuity of the Product Committee
+The PeeringDB Product Committee members serve a 2 years renewable term. Volunteers can submit their candidacy to the PeeringDB Board. The Board will elect a new Product Committee after the Board election or at any time the Board sees the necessity to ensure the continuity of the Product Committee
 
 
 #### Communication
@@ -53,18 +53,7 @@ The PeeringDB Product Committee members serve a 1 year renewable term. Volunteer
 
 Product Committee members will decide by simple majority vote on contested issues called by the Product Committee Chair
 
+### More information
+[Development Workflow](workflow.md)
 
-### Workflow
-
-We use GitHub issues located at <https://github.com/peeringdb/peeringdb/issues> with the [ZenHub](https://www.zenhub.com/) overlay.
-
-**New Issues** Evaluate if it's actually an issue, ask for feedback, etc, once it is determined valid, move it to **Icebox** and label it either bug or enhancement. Moving from New to **Icebox** probably doesn't need much discussion, it's quite easy to move back or mark as "wontfix" later. If anyone looks at an issue and it seems legit, move to **Icebox** for discussion. If it's a bug, try to reproduce it, if you can't, comment and ask for more information and leave in new.
-
-Once, with a developer involved, it's decided no more information is needed to be able to fix/implement it, it can move to **Backlog**, with a rough estimate. **Backlog** should be ordered with more important higher in the list.
-
-**Sprint** is the column that's next in the pipeline, which is everything that is approved to work on, so development starts immediately. This would be decided by the Product Committee.
-
-All other PeeringDB projects should go through this issue board since we have to decide priority. For example, when something for peeringdb-py goes into a sprint, we'll make an issue on the peeringdb-py project, and pull it into that board.
-
-**Done** means completed in development, and will be pushed to beta for review. Issues are not **Closed** until they're deployed to production.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,15 @@
+# Workflow
+
+The development roadmap is tracked using GitHub issues located at <https://github.com/peeringdb/peeringdb/issues> with the [ZenHub](https://www.zenhub.com/) overlay.
+
+**New Issues** Are evaluated to confirm they are actually an issue, which may require asking for feedback. Once an issue is determined to be valid, it is moved to **Icebox** and labeled either bug or enhancement. Moving from New to **Icebox** does not need much discussion as it is easy to move the issue back or mark it as "wontfix" later. 
+
+Product Committee members look at the issues and move them **Icebox** for discussion if the issue seems legit. If it is reported as a bug, attempts are made to reproduce it, failing that, the issue is commented and the original submitter is asked for more information. The issue will then be kept under the category **New Issues**.
+
+Once Product Committee, with developer involvment, decides that no more information is needed to be able to fix/implement an issue, it can move to **Backlog**, with a rough estimate. **Backlog** should be ordered with more important higher in the list.
+
+**Sprint** is the column that is next in the pipeline, encompassing everything that is approved to work on, so development starts immediately. This would be decided by the Product Committee.
+
+All other PeeringDB projects also go through this issue board to decide on priority. For example, when something for peeringdb-py goes into a sprint, an issue will be made on the peeringdb-py project, and pulled it into that board.
+
+**Done** means the issue is completed in development and will be pushed to beta for review. Issues are not **Closed** until they are deployed to production.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,9 @@ theme_dir: peeringdb_theme
 
 pages:
   - PeeringDB: index.md
-  - Committees: committee.md
+  - Committees: 
+    - Charters: committee.md
+    - Workflow: workflow.md
   - Governance: gov.md
   - FAQ: faq.md
   - API Specs: api_specs.md


### PR DESCRIPTION
- Clear separation between product committee and admin committee charters
- moved workflow to its own section
- changed product committee term to 2 years
- cleaned up language in workflow section