### PR TITLE
Add a new page and link for "Release Notes"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,10 @@ List all via API by taking the `id` off:
 
 Local database replication is accomplished with this [command line tool](https://github.com/peeringdb/peeringdb-py), please see the [documentation](http://peeringdb.github.io/peeringdb-py/cli/#sync) for more information.
 
+## Release Notes
+On [this page] (release_notes/index.md) you can find information about Github issues that result in a new release of PeeringDB. 
+
+
 ## Guides
 
 - [es] [Guía corta para uso de peeringdb.com](guide/guia_PeeringDB.pdf) - Fabián Mejía


### PR DESCRIPTION
I need a new page to be listed under docs.peeringdb.com (should be also listed on left banner that is seen on docs.peeringdb.com. 
The link is called Release Notes. 
I assumed the page this link can go, could be "(release_notes/index.md)". If not pls advise. 
Release notes will list the PeeringDB release notes from now on.  I will send the content of the page by mail. 
Alternatively you can create an empty page for the link to resolve to and then I can fill in content and send another pull request via Github. 

Thank you.