### PR TITLE
HOWTO manage permissions article

### DIFF
--- a/docs/howto/manage-permissions.md
+++ b/docs/howto/manage-permissions.md
@@ -1,0 +1,36 @@
+#HOWTO Manage User Permissions
+
+##Do I need a PeeringDB account?
+You only need a PeeringDB user account if you want to do one of three things:
+
+* Access contact information
+* Create, update, or delete entries in PeeringDB
+* Use PeeringDB to login to external services, using the PeeringDB Oauth service.
+
+If you just want to look up information about networks, exchanges, or facilities in PeeringDB, you can do that without an account using the web interface or the API.
+
+#How can I manage permissions for users affiliated with my organization?
+Unless you want your users to manage parts of the data your information publishes, they don’t need to be affiliated with your organization.
+
+When you allow a user account to affiliate with your organization, you can delegate some permissions to it. You can delegate them permissions related to exchanges, facilities, and networks. For each type of entry you can delegate permissions to create, update, or delete. 
+
+The table below shows an example for an affiliated user who has only been delegated permission to update the organization’s `net` object.
+
+|            | Create | Update | Delete |
+|------------|--------|--------|--------|
+| Exchanges  | NO     | NO     | NO     |
+| Facilities | NO     | NO     | NO     |
+| Networks   | NO     | YES    | NO     |
+
+Admin users for an organization can do all these things and can delegate granular permissions to users based on the needs of their organization.
+
+#How do I give permissions to a user who is already affiliated with other organizations?
+User accounts can be associated with multiple organizations. For instance, a consultant could be associated with each of their client’s organizations. Similarly, a large organization composed of several operating companies could have a different organization for each operating company in PeeringDB and have some users affiliated with those instead of trying to centralize control.
+
+The user just needs to request affiliation with each organization whose data they will be updating in PeeringDB.
+
+#How do I authenticate at external services using my PeeringDB account?
+If your organization operates a network and has the Autonomous System registered with PeeringDB, your users can use their PeeringDB accounts to authenticate at external services that have enabled PeeringDB’s Oauth service. 
+
+In mid-2021 about 150 applications had enabled PeeringDB Oauth. It is used to facilitate peering requests, use network telemetry services, and more.
+

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -6,7 +6,7 @@ Each new release has a one week beta test period on the [beta server](https://be
 
 This page was started in April 2020, and only has information about PeeringDB releases starting from that date.
 
-## Release 2.27.0
+## Release 2.27.1
 
 Beta Announcement Date: 19 May, 2021
 
@@ -22,6 +22,7 @@ Release Date: 26 May, 2021
 | [#836 Add fac_count to object ix ](https://github.com/peeringdb/peeringdb/issues/836) | In the API, added a read-only field to `ix` called `fac_count` that counts the number of facilities in which the exchange has a presence. |
 | [#922 Circumvent approval of a facility by deleting and re-adding ](https://github.com/peeringdb/peeringdb/issues/922) | Fixed bug where if a user deletes a status "pending" fac, they can re-add it and it will be status "ok" (should be "pending"). |
 | [#810 Get rid of the 'Protocols supported' fields / UI for IXes ](https://github.com/peeringdb/peeringdb/issues/810) | Removed `proto_unicast`, `proto_multicast`, and `proto_ipv6` fields from `ix` UI. The fields remain in the v2 api but `proto_ipv6` and `proto_unicast` will be populated from the existance of protocols in the exchange's `ixpfx` records. |
+| [#985 500 Error on advanced search ](https://github.com/peeringdb/peeringdb/issues/885) | Resolved an issue where unauthenticated users got a 500 error in advanced search. |
 
 
 ## Release 2.26.1


### PR DESCRIPTION
This is a brief HOWTO article on managing user permissions. It explains when an account is needed, what affiliation allows, and how granular permissions can be