### PR TITLE
Release notes for 2.28.0

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -6,9 +6,24 @@ Each new release has a one week beta test period on the [beta server](https://be
 
 This page was started in April 2020, and only has information about PeeringDB releases starting from that date.
 
+## Release 2.28.0
+
+Beta Announcement Date: 14 July 2021
+
+Release Date: 21 July 2021
+
+| **GitHub Issue** | **Summary** |
+| ----------------- | ----------- |
+| [#23 make websearch smarter ](https://github.com/peeringdb/peeringdb/issues/23) | Provide a better search experience for quick search, advanced search and API filtering. The key features are properly indexed search, which supports search based on partial name matches, and geocoded search, which supports search based on coordinates. |
+| [#965 IX-F importer: intermittent bug during consolidation of notifications ](https://github.com/peeringdb/peeringdb/issues/965) | Fixes a bug with the IX-F Member Export importer that resulted in intermittent import failures. |
+| [#863 Improve error handling when a user tries to add an object which is already there ](https://github.com/peeringdb/peeringdb/issues/863) | Increases visibility of field validation error notes by increasing size and font weight. |
+| [#375 On changing email address rescan open affiliation requests ](https://github.com/peeringdb/peeringdb/issues/375) | When a user changes their e-mail address we now automatically re-evaluate any open affiliation request that the user has that are tied to an ASN. |
+| [#923 Prevent deletion of a last technical contact if there is an existing netixlan object ](https://github.com/peeringdb/peeringdb/issues/923) | Prevents deletion of the last technical contact of existing `netixlan`, i.e. enforce that `netixlan` should always have at least one technical contact |
+
 ## Release 2.27.1
 
 Beta Announcement Date: 19 May, 2021
+
 Release Date: 26 May, 2021
 
 | **GitHub Issue** | **Summary** |
@@ -27,6 +42,7 @@ Release Date: 26 May, 2021
 ## Release 2.26.1
 
 Beta Announcement Date: 14 April, 2021
+
 Release Date: 21 April, 2021
 
 | **GitHub Issue** | **Summary** |
@@ -39,6 +55,7 @@ Release Date: 21 April, 2021
 ## Release 2.26.0
 
 Beta Announcement Date: 10 March, 2021
+
 Release Date: 24 March, 2021
 
 | **GitHub Issue** | **Summary** |
@@ -72,135 +89,3 @@ Release Date: 3 February, 2021
 | [#717 Loading time issue /cp facility view ](https://github.com/peeringdb/peeringdb/issues/717) | Fixed slow load or timeouts for loading data for some facilities |
 | [#837 Provide a friendlier explanation when entering / changing a phone number ](https://github.com/peeringdb/peeringdb/issues/837) | Provides a tooltip to help people enter E.164 formatted telephone numbers. |
 | [#541 When looking at a network record, show last updated ix<->net or fac<->net date ](https://github.com/peeringdb/peeringdb/issues/541) | Improved information about when records were last updated. |
-
-
-## Release 2.24.0
-
-Beta Announcement Date: 4 November, 2020
-Release Date: 11 November, 2020
-
-| **GitHub Issue** | **Summary** |
-| ----------------- | ----------- |
-| [#381 Network type: Add "Government"](https://github.com/peeringdb/peeringdb/issues/381) | “Government” added as a network type. |
-| [#463 Add new network type for networks that provide network services](https://github.com/peeringdb/peeringdb/issues/463) | “Network Services" for networks whose function is to provide specialized services, like DNS, RDAP, Whois or DDoS protection added as a network type. |
-| [#745 Add “Route Collector” network type](https://github.com/peeringdb/peeringdb/issues/745) | “Route Collector” added as a network type.|
-| [#747 Clean up info_type if name contains "Route Servers" or "Route Collector"](https://github.com/peeringdb/peeringdb/issues/747) | Data cleanup related to #745. All networks with route collectors have now been properly classified.|
-| [#665 Drop ixlan name from displaying at "Peers at this Exchange Point"](https://github.com/peeringdb/peeringdb/issues/665) | Simplified the user interface by removing the name of the ixlan as there is now just one ixlan per exchange point. |
-| [#775 Misleading tooltip of prefix limit fields](https://github.com/peeringdb/peeringdb/issues/775) | NO Improved the user interface with better language in the tooltip. The distinction between maximum prefix length and maximum number of prefixes should now be clearer. |
-| [#814 Suppress RDAP call for contact data/handles for NIC\.br // AUTOTOOL](https://github.com/peeringdb/peeringdb/issues/814) | Internal tool change. This change suppresses calls for contact data over RDAP because NIC.br is no longer allowed to provide direct calls for personal data. |
-| [#803 Searching for a user in /cp/peeringdb\_server/userorgaffiliationrequest results in 500](https://github.com/peeringdb/peeringdb/issues/803) | Internal tool change. Fixed an error that could return a 500 error on some searches. |
-| [#688 Automate creation of Release Notes](https://github.com/peeringdb/peeringdb/issues/688) | Internal tool change. A new script that extracts data from Github milestones to build the markdown for the release notes page. |
-| [#851 sponsorship\_notify RuntimeWarning \(was: End of Sponsorship notification email is no longer working\)](https://github.com/peeringdb/peeringdb/issues/851) | Internal tool change to improve the tracking of sponsorship renewals. |
-| [#861 add explicit order for fields in admin control panel](https://github.com/peeringdb/peeringdb/issues/861) | Internal tool change. Display fields in an explicit order. |
-| [#850  IX\-F Importer: Repeated emails are being generated for things already emailed](https://github.com/peeringdb/peeringdb/issues/850) | Internal procedure optimisation. A series of improvements to the IX-F importer tool. These changes are all related to improving notifications about data quality that were developed by the Data Ownership Task Force. |
-| [#856 IX\-F Importer: Make hyperlinks clickable when creating DeskPRO tickets](https://github.com/peeringdb/peeringdb/issues/856) | See #850. |
-| [#857 IX\-F Importer: intermittent issue with speed validation](https://github.com/peeringdb/peeringdb/issues/857) | See #850. |
-| [#858 IX\-F Importer: Make pdb\_deskpro\_publish command ignore importer tickets](https://github.com/peeringdb/peeringdb/issues/858) | See #850. |
-| [#859 IX\-F Importer: ERROR: 'IXFMemberData' object has no attribute 'ixf\_log\_entry'](https://github.com/peeringdb/peeringdb/issues/859) | See #850. |
-| [#860 IX\-F Importer Blocker: "Days until DeskPRO ticket is created" should now be ignored/removed, such that no ticket or emails happen after a delay](https://github.com/peeringdb/peeringdb/issues/860) | See #850. |
-
-
-
-## Release 2.23.0
-Beta Announcement Date: 30 September, 2020
-Release Date: 7 October, 2020
-
-| **GitHub Issue** | **Summary** |
-| ----------------- | ----------- |
-| [#833 - IX-F Importer: Add failed email resending](https://github.com/peeringdb/peeringdb/issues/833)| Implement re-send mechanic for emails that could not be sent (indicated by a sent value of null). When re-sending an email add a note to the email stating "This email could not be delivered initially and may contain stale information". Add a field to the admin-com import emails table to show this note as well. Update sent if send is successful|
-| [#832 - IX-F Importer: suggested update when it should be add + remove](https://github.com/peeringdb/peeringdb/issues/832)| In some edge cases a deletion will end up as a requirement incorrectly to a legitimate new entry still. See #770 #816 |
-| [#831 - [prod] IX-F importer: NameError: name 'EmailMultiAlternatives' is not defined ](https://github.com/peeringdb/peeringdb/issues/831)| Fixes broken email function of `ix-f` importer |
-| [#826 - Make technical poc mandatory when adding a netixlan](https://github.com/peeringdb/peeringdb/issues/826)| Upon creating a netixlan object check that net has at least one (`Technical`, `NOC`, `Policy`) `poc` and that the `poc` has an e-mail address. If not ask them to create one first. Visibility of at least one (`Technical`, `NOC`, `Policy`) `poc` has to be "Users" resp. "Public" |
-| [#825 - [beta] IX-F importer: Make Importer return non-zero when there is an error that Ops should see](https://github.com/peeringdb/peeringdb/issues/825)| Improvements to `ix-f` importer that allow for easier notification and tracking of errors for the Ops team|
-| [#824 - IX-F Preview - shows the consolidated delete operation when it shouldn't ](https://github.com/peeringdb/peeringdb/issues/824)| Simplified the UI for consolidated modifications to improve user understanding |
-| [#759 - Describe the 'never-via-routeservers' flag](https://github.com/peeringdb/peeringdb/issues/759)| Add tooltip for never-via-routeservers option: "Indicates if this network will announce its routes via route servers or not"|
-| [#571 - Facility registration tool adds identifier ](https://github.com/peeringdb/peeringdb/issues/571)| Fixes small UI bug in facility registration tool used by the Admin Committee |
-| [#481 - Add min_speed and max_speed to ixlan](https://github.com/peeringdb/peeringdb/issues/481)| Based on the discussion in #475 adds a new global setting that limits `netixlan` speed values now. It's not a property on the ixlan anymore.|
-| [#371 - Clean up users in verification queue](https://github.com/peeringdb/peeringdb/issues/371)| A tool to delete user entries older than 90 days from the so-called verification queue and run it on a regular schedule|
-| [#370 - Make Website mandatory for suggesting a facility](https://github.com/peeringdb/peeringdb/issues/370)| Website is now mandatory when suggesting a facility but zipcode only mandatory for countries that have zipcodes |
-| [#321 - Typos in locale](https://github.com/peeringdb/peeringdb/issues/321)| Fixes a number of typographical errors|
-
-## Release 2.22.0
-Beta Announcement Date: 15 July, 2020
-Release Date: 26 August, 2020
-
-| **GitHub Issue** | **Summary** |
-| ----------------- | ----------- |
-| [#249 - Add the IX-F Member Export URL to the ixlan API endpoint](https://github.com/peeringdb/peeringdb/issues/249) | There are two new fields in the ixlan section resp. the ixlan object, called ixf_ixp_member_list_url and ixf_ixp_member_list_url_visible. The first one contains the URL to the IX-F import file while the second governs the visibility of the URL. Values are the same as for the poc object, namely "Public", "Users" and "Private", defaulting to "Private" (i.e. or users who are members of the org). |
-| [#268 - Database: unique constraints](https://github.com/peeringdb/peeringdb/issues/268) | This issue fixes internal DB behaviour. |
-| [#358 - Lock ASN once the record is created](https://github.com/peeringdb/peeringdb/issues/358) | Once a network has been created, the field asn is made read-only. As the ASN is unique there is no reason to change it. Making the field read-only is to prevent unwanted side effects. |
-| [#431 - Null 'rencode' from facility](https://github.com/peeringdb/peeringdb/issues/431) | Null out all values for legacy unused rencode field, and make it read only to prepare for removal in PDB v3 [#625] (https://github.com/peeringdb/peeringdb/issues/625). |
-| [#600 - Visibility for "Allow IXP update" switch](https://github.com/peeringdb/peeringdb/issues/600) | A new field is added to the API net object, called allow_ixp_update. Furthermore, a line is added in global stats in the footer with a count (called "Automated Networks") of the networks which have "Allow IXP Update" enabled. |
-| [#649 - Possible for 'ok' ixpfx to exist in 'pending' ixlan](https://github.com/peeringdb/peeringdb/issues/649) | This issue fixes an internal bug. |
-| [#683 - Add net_count_ixf field to ix object](https://github.com/peeringdb/peeringdb/issues/683) | A field is added to the API object ix, called net_count_ixf, which indicates the number of net objects the exchange has in their IX-F JSON if they provide one. Otherwise, the value is null. |
-| [#696 - Lock some objects from being deleted by the owner](https://github.com/peeringdb/peeringdb/issues/696) | To protect operational data objects fac, ix, ixlan and org are prevented from being deleted as long as there are other objects related to it. First, these objects must be deleted before the object itself can be deleted. The attempt to delete such a protected object gives an error message and also opens a ticket with the PeeringDB support. |
-| [#697 - Creating, changing, and deleting a netixlan object](https://github.com/peeringdb/peeringdb/issues/697) | We completely re-implemented the way a connection to an exchange is handled. This new procedure allows both for a safe heads up a network can give to their peers as well as a safe way for exchanges to get rid of stale entries. Moreover, it allows networks to easily acknowledge new entries at exchanges which use the IX-F importer feature. See also the webinar for detailed information on this new procedure. |
-
-
-## Release 2.21.0
-Beta Announcement Date: 24 June, 2020
-Release Date: 1 July, 2020
-
-| **GitHub Issue** | **Summary** |
-| ----------------- | ----------- |
-| [#72 - Enable sort and reverse sort of IP column in IX display](https://github.com/peeringdb/peeringdb/issues/72) | Sort and reverse sort of IP column in IX display are added. Sort of the IP addresses in the expected natural order. The IPv4 address is the primary sort key. The IPv6 address is the secondary key. |
-| [#121 - missing delete button for organisations](https://github.com/peeringdb/peeringdb/issues/121) | New feature. An admin user is able to delete an org if it has no live objects under it. |
-| [#290 - Offer 2FA](https://github.com/peeringdb/peeringdb/issues/290) | 2FA is offered now. The implementation includes <ul><li> optional 2FA using [TOTP](https://tools.ietf.org/html/rfc6238) is offered</li><li> there is a knob in the user profile to enable and set it up</li><li> email recovery is added using the verified user email address</li><li> an icon is added in the org admin section to denote to org admins if users have 2FA enabled </li></ul> |
-| [#352 - Mark IXP peering LAN as bogon](https://github.com/peeringdb/peeringdb/issues/352) | Allow IXP to tag their LAN prefixes as bogons. In general, LAN prefixes should not be visible in the DFZ. If it should be visible, IXPs are able to debogonise them |
-| [#356 - Sorting by clicking table headers should use local-compare](https://github.com/peeringdb/peeringdb/issues/356) | Bugfix. Sorting now honours locale-sorting |
-| [#519 - Make spelling of traffic levels consistent](https://github.com/peeringdb/peeringdb/issues/519) | This is a bug fix and a minor improvement. Spelling is made consistent and traffic levels up to 100+Tbps are added.|
-| [#526 - Show "Last Updated" fields on fac, ix, org records](https://github.com/peeringdb/peeringdb/issues/526) | A "Last Updated" field is visible now for fac, ix, and org objects |
-| [#537 - Posting https://www.peeringdb.com onto social media doesn't select a good preview image](https://github.com/peeringdb/peeringdb/issues/537) | Add opengraph image for page preview.|
-| [#566 - Should deleted personal data be accessable through the API?](https://github.com/peeringdb/peeringdb/issues/566) | If a poc object is deleted it is made immediately non-gettable via the API, too. In case the corresponding net object was deleted unintentionally the object is still kept in the DB. After 30 days it will be hard-deleted. |
-| [#569 - Don't return any POC data with status=deleted](https://github.com/peeringdb/peeringdb/issues/569) | POC objects do have a visibility scope. If a POC record is deleted it should not be able to retrieve it at all, even if visibility had been set to "public" before. The data will still be kept internally for 30 days for rollback if the deletion happened unintentionally. After 30 days the record will be hard-deleted.|
-| [#580 - Add a clear error message, when user tries to re-add a previously deleted facility](https://github.com/peeringdb/peeringdb/issues/580) | Bug fix for an unclear behaviour. If a connection from a network to a facility was deleted the user was unable to re-add this connection by themselves and an unclear error message was given. Now, the user is able to re-add the connection. |
-| [#618 - Support alternative direction of writing, e.g. Arabic](https://github.com/peeringdb/peeringdb/issues/618) | For right-to-left written languages, the entire layout of the PeeringDB website has to be flipped around. |
-| [#644 - Undeleting an ixlan with an emtpy IPv4 XOR IPv6 field throws a silly error](https://github.com/peeringdb/peeringdb/issues/644) |Bugfix for the Admin Committee UI. An empty field was considered to be a legit non-null value and the system hence enforced uniqueness |
-| [#650 - Add pointer from API docs to tutorial](https://github.com/peeringdb/peeringdb/issues/650) | A URL is added from the API documentation website to the PeeringDB tutorials |
-| [#654 - Add pointer from API docs to tutorial](https://github.com/peeringdb/peeringdb/issues/654) | Bugfix for the Admin Committee UI. |
-| [#663 - change default encoding of API calls to 'utf-8'](https://github.com/peeringdb/peeringdb/issues/663) | The output of API calls will change from content-type: application/json; charset=iso-8859-1 to content-type: application/json; charset=utf-8 |
-| [#664 - Selection should only present undeleted objects](https://github.com/peeringdb/peeringdb/issues/664) | Admin Committee only related. Only non-deleted should be presented for selection |
-| [#666 - Selection should only present undeleted objects](https://github.com/peeringdb/peeringdb/issues/666) | When changing owner of an ix admin GUI borks because of "Ixlan for exchange already exists" |
-| [#669 - Add help text to "Add {Facility, Network, Exchange} tab](https://github.com/peeringdb/peeringdb/issues/669) | Added a better help text to make crystal clear that adding a Facility, Network, or Exchange means that you are owning this object. |
-| [#679 - Add read-only Superuser](https://github.com/peeringdb/peeringdb/issues/679) | Provide PC members with a read-only access to the Admin UI. |
-| [#712 - User is unable to update their net record ](https://github.com/peeringdb/peeringdb/issues/712) | Bug fix. Missing pointer to where the non-compliant value is |
-
-
-## Release 2.20.2
-Release Date: 23 April, 2020
-
-| **GitHub Issue** | **Summary** |
-| ----------------- | ----------- |
-| [#707 - Make source not required for IRR records](https://github.com/peeringdb/peeringdb/issues/707) | Making source not required for IRR records. This requirement was an oversight during implementation of [#151 - Validation of IRR Records] (https://github.com/peeringdb/peeringdb/issues/151) that was released with 2.20.0 - see below. Product Committee revisited the issue after 2.20.0 and reports of concern from community and decided to retract the requirement in an emergency release|
-
-## Release 2.20.1
-Release Date: 21 April, 2020
-
-| **GitHub Issue** | **Summary** |
-| ----------------- | ----------- |
-| [#702 - Requests from peeringdb-py error 500](https://github.com/peeringdb/peeringdb/issues/702) | Emergency release for a config change |
-
-## Release 2.20.0
-Beta Announcement Date: 15 April, 2020
-Release Date: 21 April, 2020
-
-| **GitHub Issue** | **Summary** |
-| ----------------- | ----------- |
-| [#151 - Validation of IRR Records](https://github.com/peeringdb/peeringdb/issues/151) | To make the IRR as-set/route-set field of more operational value, strict rules apply <ul><li> the as-set/rs-set name has to conform to RFC 2622 (5.1 and 5.2)</li><li> the source may be specified by AS-SET@SOURCE or SOURCE::AS-SET (preferred)</li> <li> valid sources are taken from the list of known IRRs</li><li> multiple values must be separated by either ,, , or , (i.e. comma, space or comma followed by space)</li></ul> |
-| [#189 - Improve explanatory and help text](https://github.com/peeringdb/peeringdb/issues/189) | A clear help text is added for requesting affiliation to an organisation.  |
-| [#251 - Limit number of concurrent affiliation requests per user](https://github.com/peeringdb/peeringdb/issues/251) | In order to reduce organization affiliation request spamming, the number of pending organization requests has been limited to 5. |
-| [#295 Desk pro tickets -> DeskPRO tickets](https://github.com/peeringdb/peeringdb/issues/295)  | This is a bug fix and only affects the Admin UI. |
-| [#378 - Add contact information for Facilities (fac) the same way as for ix and net](https://github.com/peeringdb/peeringdb/issues/378) | Contact information is added to Facilities and IXP. |
-| [#452 - Org/Network name of a sponsor should not link to /sponsors, only the sponsor badge should](https://github.com/peeringdb/peeringdb/issues/452) | This is a bug fix. From now on only when clicking on the sponsor badge will direct to the sponsor page. |
-| [#462 - Route-server URL starting with ssh://](https://github.com/peeringdb/peeringdb/issues/462) | Add SSH as supported protocol. |
-| [#539 - Add attribute 'operational' to 'netixlan'](https://github.com/peeringdb/peeringdb/issues/539) | This is a new feature and allows networks to give early notice to their peers that they soon will show up at an IXP. There is a new check box when adding an IXP connection. By default, a connection is considered operational and the box is ticked. When the connection is still in provisioning status, please untick the box. When viewing, the warning glyphicon is shown right to the network name. The correspondent API object netixlan is enhanced by a boolean field operational defaulting to true. This feature is in line with the [Data Ownership Policy](../gov/misc/2020-04-06_PeeringDB_Data_Ownership_Policy_Document_v1.0.pdf). |
-| [#548 - containerize server](https://github.com/peeringdb/peeringdb/issues/548) | Internal software deployment system has been changed to use containers which reduces time spent by the ops team for deployments, allows for better scaling, and reduces the cost of entry for new developers to write and test their code. |
-| [#555 - Notes field translate button disappears](https://github.com/peeringdb/peeringdb/issues/555) | This is a bug fix. The "Translate" button is there for a moment and then disappeared. |
-| [#557 - Show all languages on beta, even if translation is not ready for prod](https://github.com/peeringdb/peeringdb/issues/557) | As soon as a new translation is starting it is available on the beta to help the translators and to encourage the community for input. |
-| [#598 - bug caused by the org affiliationship request without an asn](https://github.com/peeringdb/peeringdb/issues/598) | This is a bug fix and is only relevant for the PeeringDB Admin Committee. |
-| [#609 - When creating an ix via the API also return ixlan_id and ixpfx_id](https://github.com/peeringdb/peeringdb/issues/609) | When creating an IX record via API, the call will also return the implicitly created ixlan_id and ixpfx_id. This makes it simpler and reduces the number of calls that need to be made to the API. |
-| [#615 - Insert links into ID fields in DESKPRO AUTOASN tickets](https://github.com/peeringdb/peeringdb/issues/615) | This only affects tickets generated for PeeringDB Admin Committee. A link to the object in the UI is added. |
-| [#626 - Update API docs](https://github.com/peeringdb/peeringdb/issues/626) | Internal mechanisms for generating the API docs have been updated to current standards. This also allows for easier user contributions to the docs themselves. |
-| [#634 - Remove support for python2](https://github.com/peeringdb/peeringdb/issues/634) | Python 2.7 and 3.4 support is being removed from PeeringDB packages. |
-| [#636 - Don't create a new net object, when there only is an ASN block](https://github.com/peeringdb/peeringdb/issues/636) | This is a bug fix and is only relevant for the PeeringDB Admin Committee. |
-| [#667 - Fix use autocomplete fields in the admincom controlpanel to speed up loading times](https://github.com/peeringdb/peeringdb/issues/667) | This is a bug fix and is only relevant for the PeeringDB Admin Committee. |

--- a/docs/release_notes/release_notes_2020.md
+++ b/docs/release_notes/release_notes_2020.md
@@ -1,0 +1,142 @@
+# Release Notes
+
+The release notes list the GitHub issues and a summary of what has changed in PeeringDB software releases.
+
+Each new release has a one week beta test period on the [beta server](https://beta.peeringdb.com/) before it goes live.  The beta and new releases are announced on the [PeeringDB Announce Mailing List](https://lists.peeringdb.com/cgi-bin/mailman/listinfo/pdb-announce) and on [Twitter](https://twitter.com/PeeringDB), [LinkedIn](https://www.linkedin.com/company/peeringdb) and [Facebook](https://www.facebook.com/peeringdb).
+
+**This page shows release notes from 2020. Release notes for the currentyear are available [here](https://docs.peeringdb.com/release_notes/).**
+
+## Release 2.24.0
+
+Beta Announcement Date: 4 November, 2020
+
+Release Date: 11 November, 2020
+
+| **GitHub Issue** | **Summary** |
+| ----------------- | ----------- |
+| [#381 Network type: Add "Government"](https://github.com/peeringdb/peeringdb/issues/381) | “Government” added as a network type. |
+| [#463 Add new network type for networks that provide network services](https://github.com/peeringdb/peeringdb/issues/463) | “Network Services" for networks whose function is to provide specialized services, like DNS, RDAP, Whois or DDoS protection added as a network type. |
+| [#745 Add “Route Collector” network type](https://github.com/peeringdb/peeringdb/issues/745) | “Route Collector” added as a network type.|
+| [#747 Clean up info_type if name contains "Route Servers" or "Route Collector"](https://github.com/peeringdb/peeringdb/issues/747) | Data cleanup related to #745. All networks with route collectors have now been properly classified.|
+| [#665 Drop ixlan name from displaying at "Peers at this Exchange Point"](https://github.com/peeringdb/peeringdb/issues/665) | Simplified the user interface by removing the name of the ixlan as there is now just one ixlan per exchange point. |
+| [#775 Misleading tooltip of prefix limit fields](https://github.com/peeringdb/peeringdb/issues/775) | NO Improved the user interface with better language in the tooltip. The distinction between maximum prefix length and maximum number of prefixes should now be clearer. |
+| [#814 Suppress RDAP call for contact data/handles for NIC\.br // AUTOTOOL](https://github.com/peeringdb/peeringdb/issues/814) | Internal tool change. This change suppresses calls for contact data over RDAP because NIC.br is no longer allowed to provide direct calls for personal data. |
+| [#803 Searching for a user in /cp/peeringdb\_server/userorgaffiliationrequest results in 500](https://github.com/peeringdb/peeringdb/issues/803) | Internal tool change. Fixed an error that could return a 500 error on some searches. |
+| [#688 Automate creation of Release Notes](https://github.com/peeringdb/peeringdb/issues/688) | Internal tool change. A new script that extracts data from Github milestones to build the markdown for the release notes page. |
+| [#851 sponsorship\_notify RuntimeWarning \(was: End of Sponsorship notification email is no longer working\)](https://github.com/peeringdb/peeringdb/issues/851) | Internal tool change to improve the tracking of sponsorship renewals. |
+| [#861 add explicit order for fields in admin control panel](https://github.com/peeringdb/peeringdb/issues/861) | Internal tool change. Display fields in an explicit order. |
+| [#850  IX\-F Importer: Repeated emails are being generated for things already emailed](https://github.com/peeringdb/peeringdb/issues/850) | Internal procedure optimisation. A series of improvements to the IX-F importer tool. These changes are all related to improving notifications about data quality that were developed by the Data Ownership Task Force. |
+| [#856 IX\-F Importer: Make hyperlinks clickable when creating DeskPRO tickets](https://github.com/peeringdb/peeringdb/issues/856) | See #850. |
+| [#857 IX\-F Importer: intermittent issue with speed validation](https://github.com/peeringdb/peeringdb/issues/857) | See #850. |
+| [#858 IX\-F Importer: Make pdb\_deskpro\_publish command ignore importer tickets](https://github.com/peeringdb/peeringdb/issues/858) | See #850. |
+| [#859 IX\-F Importer: ERROR: 'IXFMemberData' object has no attribute 'ixf\_log\_entry'](https://github.com/peeringdb/peeringdb/issues/859) | See #850. |
+| [#860 IX\-F Importer Blocker: "Days until DeskPRO ticket is created" should now be ignored/removed, such that no ticket or emails happen after a delay](https://github.com/peeringdb/peeringdb/issues/860) | See #850. |
+
+
+
+## Release 2.23.0
+Beta Announcement Date: 30 September, 2020
+
+Release Date: 7 October, 2020
+
+| **GitHub Issue** | **Summary** |
+| ----------------- | ----------- |
+| [#833 - IX-F Importer: Add failed email resending](https://github.com/peeringdb/peeringdb/issues/833)| Implement re-send mechanic for emails that could not be sent (indicated by a sent value of null). When re-sending an email add a note to the email stating "This email could not be delivered initially and may contain stale information". Add a field to the admin-com import emails table to show this note as well. Update sent if send is successful|
+| [#832 - IX-F Importer: suggested update when it should be add + remove](https://github.com/peeringdb/peeringdb/issues/832)| In some edge cases a deletion will end up as a requirement incorrectly to a legitimate new entry still. See #770 #816 |
+| [#831 - [prod] IX-F importer: NameError: name 'EmailMultiAlternatives' is not defined ](https://github.com/peeringdb/peeringdb/issues/831)| Fixes broken email function of `ix-f` importer |
+| [#826 - Make technical poc mandatory when adding a netixlan](https://github.com/peeringdb/peeringdb/issues/826)| Upon creating a netixlan object check that net has at least one (`Technical`, `NOC`, `Policy`) `poc` and that the `poc` has an e-mail address. If not ask them to create one first. Visibility of at least one (`Technical`, `NOC`, `Policy`) `poc` has to be "Users" resp. "Public" |
+| [#825 - [beta] IX-F importer: Make Importer return non-zero when there is an error that Ops should see](https://github.com/peeringdb/peeringdb/issues/825)| Improvements to `ix-f` importer that allow for easier notification and tracking of errors for the Ops team|
+| [#824 - IX-F Preview - shows the consolidated delete operation when it shouldn't ](https://github.com/peeringdb/peeringdb/issues/824)| Simplified the UI for consolidated modifications to improve user understanding |
+| [#759 - Describe the 'never-via-routeservers' flag](https://github.com/peeringdb/peeringdb/issues/759)| Add tooltip for never-via-routeservers option: "Indicates if this network will announce its routes via route servers or not"|
+| [#571 - Facility registration tool adds identifier ](https://github.com/peeringdb/peeringdb/issues/571)| Fixes small UI bug in facility registration tool used by the Admin Committee |
+| [#481 - Add min_speed and max_speed to ixlan](https://github.com/peeringdb/peeringdb/issues/481)| Based on the discussion in #475 adds a new global setting that limits `netixlan` speed values now. It's not a property on the ixlan anymore.|
+| [#371 - Clean up users in verification queue](https://github.com/peeringdb/peeringdb/issues/371)| A tool to delete user entries older than 90 days from the so-called verification queue and run it on a regular schedule|
+| [#370 - Make Website mandatory for suggesting a facility](https://github.com/peeringdb/peeringdb/issues/370)| Website is now mandatory when suggesting a facility but zipcode only mandatory for countries that have zipcodes |
+| [#321 - Typos in locale](https://github.com/peeringdb/peeringdb/issues/321)| Fixes a number of typographical errors|
+
+## Release 2.22.0
+Beta Announcement Date: 15 July, 2020
+
+Release Date: 26 August, 2020
+
+| **GitHub Issue** | **Summary** |
+| ----------------- | ----------- |
+| [#249 - Add the IX-F Member Export URL to the ixlan API endpoint](https://github.com/peeringdb/peeringdb/issues/249) | There are two new fields in the ixlan section resp. the ixlan object, called ixf_ixp_member_list_url and ixf_ixp_member_list_url_visible. The first one contains the URL to the IX-F import file while the second governs the visibility of the URL. Values are the same as for the poc object, namely "Public", "Users" and "Private", defaulting to "Private" (i.e. or users who are members of the org). |
+| [#268 - Database: unique constraints](https://github.com/peeringdb/peeringdb/issues/268) | This issue fixes internal DB behaviour. |
+| [#358 - Lock ASN once the record is created](https://github.com/peeringdb/peeringdb/issues/358) | Once a network has been created, the field asn is made read-only. As the ASN is unique there is no reason to change it. Making the field read-only is to prevent unwanted side effects. |
+| [#431 - Null 'rencode' from facility](https://github.com/peeringdb/peeringdb/issues/431) | Null out all values for legacy unused rencode field, and make it read only to prepare for removal in PDB v3 [#625] (https://github.com/peeringdb/peeringdb/issues/625). |
+| [#600 - Visibility for "Allow IXP update" switch](https://github.com/peeringdb/peeringdb/issues/600) | A new field is added to the API net object, called allow_ixp_update. Furthermore, a line is added in global stats in the footer with a count (called "Automated Networks") of the networks which have "Allow IXP Update" enabled. |
+| [#649 - Possible for 'ok' ixpfx to exist in 'pending' ixlan](https://github.com/peeringdb/peeringdb/issues/649) | This issue fixes an internal bug. |
+| [#683 - Add net_count_ixf field to ix object](https://github.com/peeringdb/peeringdb/issues/683) | A field is added to the API object ix, called net_count_ixf, which indicates the number of net objects the exchange has in their IX-F JSON if they provide one. Otherwise, the value is null. |
+| [#696 - Lock some objects from being deleted by the owner](https://github.com/peeringdb/peeringdb/issues/696) | To protect operational data objects fac, ix, ixlan and org are prevented from being deleted as long as there are other objects related to it. First, these objects must be deleted before the object itself can be deleted. The attempt to delete such a protected object gives an error message and also opens a ticket with the PeeringDB support. |
+| [#697 - Creating, changing, and deleting a netixlan object](https://github.com/peeringdb/peeringdb/issues/697) | We completely re-implemented the way a connection to an exchange is handled. This new procedure allows both for a safe heads up a network can give to their peers as well as a safe way for exchanges to get rid of stale entries. Moreover, it allows networks to easily acknowledge new entries at exchanges which use the IX-F importer feature. See also the webinar for detailed information on this new procedure. |
+
+
+## Release 2.21.0
+Beta Announcement Date: 24 June, 2020
+
+Release Date: 1 July, 2020
+
+| **GitHub Issue** | **Summary** |
+| ----------------- | ----------- |
+| [#72 - Enable sort and reverse sort of IP column in IX display](https://github.com/peeringdb/peeringdb/issues/72) | Sort and reverse sort of IP column in IX display are added. Sort of the IP addresses in the expected natural order. The IPv4 address is the primary sort key. The IPv6 address is the secondary key. |
+| [#121 - missing delete button for organisations](https://github.com/peeringdb/peeringdb/issues/121) | New feature. An admin user is able to delete an org if it has no live objects under it. |
+| [#290 - Offer 2FA](https://github.com/peeringdb/peeringdb/issues/290) | 2FA is offered now. The implementation includes <ul><li> optional 2FA using [TOTP](https://tools.ietf.org/html/rfc6238) is offered</li><li> there is a knob in the user profile to enable and set it up</li><li> email recovery is added using the verified user email address</li><li> an icon is added in the org admin section to denote to org admins if users have 2FA enabled </li></ul> |
+| [#352 - Mark IXP peering LAN as bogon](https://github.com/peeringdb/peeringdb/issues/352) | Allow IXP to tag their LAN prefixes as bogons. In general, LAN prefixes should not be visible in the DFZ. If it should be visible, IXPs are able to debogonise them |
+| [#356 - Sorting by clicking table headers should use local-compare](https://github.com/peeringdb/peeringdb/issues/356) | Bugfix. Sorting now honours locale-sorting |
+| [#519 - Make spelling of traffic levels consistent](https://github.com/peeringdb/peeringdb/issues/519) | This is a bug fix and a minor improvement. Spelling is made consistent and traffic levels up to 100+Tbps are added.|
+| [#526 - Show "Last Updated" fields on fac, ix, org records](https://github.com/peeringdb/peeringdb/issues/526) | A "Last Updated" field is visible now for fac, ix, and org objects |
+| [#537 - Posting https://www.peeringdb.com onto social media doesn't select a good preview image](https://github.com/peeringdb/peeringdb/issues/537) | Add opengraph image for page preview.|
+| [#566 - Should deleted personal data be accessable through the API?](https://github.com/peeringdb/peeringdb/issues/566) | If a poc object is deleted it is made immediately non-gettable via the API, too. In case the corresponding net object was deleted unintentionally the object is still kept in the DB. After 30 days it will be hard-deleted. |
+| [#569 - Don't return any POC data with status=deleted](https://github.com/peeringdb/peeringdb/issues/569) | POC objects do have a visibility scope. If a POC record is deleted it should not be able to retrieve it at all, even if visibility had been set to "public" before. The data will still be kept internally for 30 days for rollback if the deletion happened unintentionally. After 30 days the record will be hard-deleted.|
+| [#580 - Add a clear error message, when user tries to re-add a previously deleted facility](https://github.com/peeringdb/peeringdb/issues/580) | Bug fix for an unclear behaviour. If a connection from a network to a facility was deleted the user was unable to re-add this connection by themselves and an unclear error message was given. Now, the user is able to re-add the connection. |
+| [#618 - Support alternative direction of writing, e.g. Arabic](https://github.com/peeringdb/peeringdb/issues/618) | For right-to-left written languages, the entire layout of the PeeringDB website has to be flipped around. |
+| [#644 - Undeleting an ixlan with an emtpy IPv4 XOR IPv6 field throws a silly error](https://github.com/peeringdb/peeringdb/issues/644) |Bugfix for the Admin Committee UI. An empty field was considered to be a legit non-null value and the system hence enforced uniqueness |
+| [#650 - Add pointer from API docs to tutorial](https://github.com/peeringdb/peeringdb/issues/650) | A URL is added from the API documentation website to the PeeringDB tutorials |
+| [#654 - Add pointer from API docs to tutorial](https://github.com/peeringdb/peeringdb/issues/654) | Bugfix for the Admin Committee UI. |
+| [#663 - change default encoding of API calls to 'utf-8'](https://github.com/peeringdb/peeringdb/issues/663) | The output of API calls will change from content-type: application/json; charset=iso-8859-1 to content-type: application/json; charset=utf-8 |
+| [#664 - Selection should only present undeleted objects](https://github.com/peeringdb/peeringdb/issues/664) | Admin Committee only related. Only non-deleted should be presented for selection |
+| [#666 - Selection should only present undeleted objects](https://github.com/peeringdb/peeringdb/issues/666) | When changing owner of an ix admin GUI borks because of "Ixlan for exchange already exists" |
+| [#669 - Add help text to "Add {Facility, Network, Exchange} tab](https://github.com/peeringdb/peeringdb/issues/669) | Added a better help text to make crystal clear that adding a Facility, Network, or Exchange means that you are owning this object. |
+| [#679 - Add read-only Superuser](https://github.com/peeringdb/peeringdb/issues/679) | Provide PC members with a read-only access to the Admin UI. |
+| [#712 - User is unable to update their net record ](https://github.com/peeringdb/peeringdb/issues/712) | Bug fix. Missing pointer to where the non-compliant value is |
+
+
+## Release 2.20.2
+Release Date: 23 April, 2020
+
+| **GitHub Issue** | **Summary** |
+| ----------------- | ----------- |
+| [#707 - Make source not required for IRR records](https://github.com/peeringdb/peeringdb/issues/707) | Making source not required for IRR records. This requirement was an oversight during implementation of [#151 - Validation of IRR Records] (https://github.com/peeringdb/peeringdb/issues/151) that was released with 2.20.0 - see below. Product Committee revisited the issue after 2.20.0 and reports of concern from community and decided to retract the requirement in an emergency release|
+
+## Release 2.20.1
+Release Date: 21 April, 2020
+
+| **GitHub Issue** | **Summary** |
+| ----------------- | ----------- |
+| [#702 - Requests from peeringdb-py error 500](https://github.com/peeringdb/peeringdb/issues/702) | Emergency release for a config change |
+
+## Release 2.20.0
+Beta Announcement Date: 15 April, 2020
+Release Date: 21 April, 2020
+
+| **GitHub Issue** | **Summary** |
+| ----------------- | ----------- |
+| [#151 - Validation of IRR Records](https://github.com/peeringdb/peeringdb/issues/151) | To make the IRR as-set/route-set field of more operational value, strict rules apply <ul><li> the as-set/rs-set name has to conform to RFC 2622 (5.1 and 5.2)</li><li> the source may be specified by AS-SET@SOURCE or SOURCE::AS-SET (preferred)</li> <li> valid sources are taken from the list of known IRRs</li><li> multiple values must be separated by either ,, , or , (i.e. comma, space or comma followed by space)</li></ul> |
+| [#189 - Improve explanatory and help text](https://github.com/peeringdb/peeringdb/issues/189) | A clear help text is added for requesting affiliation to an organisation.  |
+| [#251 - Limit number of concurrent affiliation requests per user](https://github.com/peeringdb/peeringdb/issues/251) | In order to reduce organization affiliation request spamming, the number of pending organization requests has been limited to 5. |
+| [#295 Desk pro tickets -> DeskPRO tickets](https://github.com/peeringdb/peeringdb/issues/295)  | This is a bug fix and only affects the Admin UI. |
+| [#378 - Add contact information for Facilities (fac) the same way as for ix and net](https://github.com/peeringdb/peeringdb/issues/378) | Contact information is added to Facilities and IXP. |
+| [#452 - Org/Network name of a sponsor should not link to /sponsors, only the sponsor badge should](https://github.com/peeringdb/peeringdb/issues/452) | This is a bug fix. From now on only when clicking on the sponsor badge will direct to the sponsor page. |
+| [#462 - Route-server URL starting with ssh://](https://github.com/peeringdb/peeringdb/issues/462) | Add SSH as supported protocol. |
+| [#539 - Add attribute 'operational' to 'netixlan'](https://github.com/peeringdb/peeringdb/issues/539) | This is a new feature and allows networks to give early notice to their peers that they soon will show up at an IXP. There is a new check box when adding an IXP connection. By default, a connection is considered operational and the box is ticked. When the connection is still in provisioning status, please untick the box. When viewing, the warning glyphicon is shown right to the network name. The correspondent API object netixlan is enhanced by a boolean field operational defaulting to true. This feature is in line with the [Data Ownership Policy](../gov/misc/2020-04-06_PeeringDB_Data_Ownership_Policy_Document_v1.0.pdf). |
+| [#548 - containerize server](https://github.com/peeringdb/peeringdb/issues/548) | Internal software deployment system has been changed to use containers which reduces time spent by the ops team for deployments, allows for better scaling, and reduces the cost of entry for new developers to write and test their code. |
+| [#555 - Notes field translate button disappears](https://github.com/peeringdb/peeringdb/issues/555) | This is a bug fix. The "Translate" button is there for a moment and then disappeared. |
+| [#557 - Show all languages on beta, even if translation is not ready for prod](https://github.com/peeringdb/peeringdb/issues/557) | As soon as a new translation is starting it is available on the beta to help the translators and to encourage the community for input. |
+| [#598 - bug caused by the org affiliationship request without an asn](https://github.com/peeringdb/peeringdb/issues/598) | This is a bug fix and is only relevant for the PeeringDB Admin Committee. |
+| [#609 - When creating an ix via the API also return ixlan_id and ixpfx_id](https://github.com/peeringdb/peeringdb/issues/609) | When creating an IX record via API, the call will also return the implicitly created ixlan_id and ixpfx_id. This makes it simpler and reduces the number of calls that need to be made to the API. |
+| [#615 - Insert links into ID fields in DESKPRO AUTOASN tickets](https://github.com/peeringdb/peeringdb/issues/615) | This only affects tickets generated for PeeringDB Admin Committee. A link to the object in the UI is added. |
+| [#626 - Update API docs](https://github.com/peeringdb/peeringdb/issues/626) | Internal mechanisms for generating the API docs have been updated to current standards. This also allows for easier user contributions to the docs themselves. |
+| [#634 - Remove support for python2](https://github.com/peeringdb/peeringdb/issues/634) | Python 2.7 and 3.4 support is being removed from PeeringDB packages. |
+| [#636 - Don't create a new net object, when there only is an ASN block](https://github.com/peeringdb/peeringdb/issues/636) | This is a bug fix and is only relevant for the PeeringDB Admin Committee. |
+| [#667 - Fix use autocomplete fields in the admincom controlpanel to speed up loading times](https://github.com/peeringdb/peeringdb/issues/667) | This is a bug fix and is only relevant for the PeeringDB Admin Committee. |


### PR DESCRIPTION
Release notes for changes in 2.28.0 in beta. This update also archives the release notes from calendar year 2020 to a separate page, leaving the index page for the current calendar year