### PR TITLE
Fixes to typos

### DIFF
--- a/docs/blog/peeringdb_is_developed_by_its_community.md
+++ b/docs/blog/peeringdb_is_developed_by_its_community.md
@@ -4,7 +4,7 @@ PeeringDB community members have contributed two significant improvements that w
 ![Lagos Techie on Unsplash](images/lagos_techie_on_unsplash.jpeg)
 
 ## Simple Search is Smarter Search
-As [reported by NANOG](https://nanog.org/stories/hackathon-solves-real-world-tech-issue/) last week, code developed by Brad Schwyzer, James Lamanna, and Jeff Kala developed code that significantly improves the accuracy of what we call Simple Search. This is the main search box on the front page or the basic API call. Until this month it provided an enthusiastic number of responses when searching for things like small AS Numbers. 
+As [reported by NANOG](https://nanog.org/stories/hackathon-solves-real-world-tech-issue/) last week, we have deployed code developed by Brad Schwyzer, James Lamanna, and Jeff Kala that significantly improves the accuracy of what we call Simple Search. This is the main search box on the front page or the basic API call. Until this month it provided an enthusiastic number of responses when searching for things like small AS Numbers. 
 
 While the answers weren’t wrong, our users needed to pay extra attention to find what they needed. Brad, James, and Jeff developed logic to work out what users are likely to be searching for and give them the most relevant results. Simple Search now knows about the difference between an AS Number, an IPv4 address, and an IPv6 address. It will only respond with IP address information if at least two segments of the address are included in the search.
 

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -11,16 +11,16 @@ Release Date: 19 January 2022
 
 | **GitHub Issue** | **Summary** |
 | ----------------- | ----------- |
-| [#1083 Nanog 83 Hackathon improvements to the PeeringDB Website](https://github.com/peeringdb/peeringdb/issues/1083) | When using simple search on the front page of www.peeringdb.com (or via the API) searches for numbers return the most relevant results. Key changes include searching for a short ASN returns just that network, and searches for two segments of an IP address are required to return related `ix` and `net` objects. |
+| [#1083 Nanog 83 Hackathon improvements to the PeeringDB Website](https://github.com/peeringdb/peeringdb/issues/1083) | When using simple search on the front page of www.peeringdb.com (or via the API) searches for numbers return the most relevant results. Key changes include: searching for a short ASN returns just that network, and searches for two segments of an IP address are required to return related `ix` and `net` objects. |
 | [#1070 OpenID Connect integration](https://github.com/peeringdb/peeringdb/issues/1070) | Allows organizations using PeeringDB to enable an identity federation with a managed service. |
 | [#692 Add FIDO U2F 2FA support](https://github.com/peeringdb/peeringdb/issues/692) | Adds support for FIDO U2F hardware tokens, allowing users to enable 2FA without relying on a TOTP app. |
-| [#1033 Clicking "Add" to add a user api-key without providing a name for the key raises Internal Error](https://github.com/peeringdb/peeringdb/issues/1033) | Fixes a bug where unnamed user api-keys could not bne added and there was just an internal error. |
+| [#1033 Clicking "Add" to add a user api-key without providing a name for the key raises Internal Error](https://github.com/peeringdb/peeringdb/issues/1033) | Fixes a bug where unnamed user api-keys could not be added and there was just an internal error. |
 | [#374 make URL required for new objects](https://github.com/peeringdb/peeringdb/issues/374) | A URL to a website is now required when adding new objects. |
 | [#469 Add IXP to AS record / dropdown limited](https://github.com/peeringdb/peeringdb/issues/469) | Fixes a bug that limited the number of entries in the dropdown menu when adding an `ix` to a `net`. |
-| [#284 global stats don't show up at login screen](https://github.com/peeringdb/peeringdb/issues/284) | Global stats are now shown at the login web page |
+| [#284 global stats don't show up at login screen](https://github.com/peeringdb/peeringdb/issues/284) | Global stats are now shown at the login web page. |
 | [#874 Better error message when entering the wrong password for email change](https://github.com/peeringdb/peeringdb/issues/874) | Improved the error message when entering the wrong password for an e-mail change. |
 | [#365 Username retrieval non-existant email bug](https://github.com/peeringdb/peeringdb/issues/365) | Fixes a bug where we attempted to send mail to non-existant addresses. |
-| [#735 Cascade delete when performed by superuser](https://github.com/peeringdb/peeringdb/issues/735) | Admin users canb now cascade delete through the admin interface. |
+| [#735 Cascade delete when performed by superuser](https://github.com/peeringdb/peeringdb/issues/735) | Admin users can now cascade delete through the admin interface. |
 | [#901 Creating a facility that matches the name of a soft-deleted facility will cause the entry to bypass the verification queue](https://github.com/peeringdb/peeringdb/issues/901) | Fixes a bug where `fac` creation could bypass the validation process. |
 | [#921 irr source validator doesn't allow for hyphens in source](https://github.com/peeringdb/peeringdb/issues/921) | IRRs with a hyphen in the name, like ARIN-NONAUTH, are now supported. |
 | [#1060 "HARAKIRI ON WORKER" issues need to be resolved](https://github.com/peeringdb/peeringdb/issues/1060) | Fixes an operational issue. |


### PR DESCRIPTION
This fixes two spelling mistakes in the 2.33.0 release notes and a sentence that did not parse correctly in the blog post about volunteer developers