### PR TITLE
Add missing word in AC approval guidelines

### DIFF
--- a/docs/committee/admin/approval-guidelines.md
+++ b/docs/committee/admin/approval-guidelines.md
@@ -86,7 +86,7 @@ PeeringDB encourages but does not require its users to follow industry best prac
 
 A “facility” is a physical location where two or more IP Networks or IXPs interconnect with each other. The key to approving Facility objects is to confirm with multiple existing PeeringDB users that a facility exists. 
 
-* Note: We will need to extend PeeringDB's to support the workflow described here.
+* Note: We will need to extend PeeringDB's software to support the workflow described here.
 * Note: The IP addresses used in the attestation process will be logged.
 
 ### Validation mechanisms

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -19,7 +19,7 @@ Release Date: 22 March 2022
 | [#656 Sort user IDs in https://peeringdb.com/cp/peeringdb_server/userpermission/xxxxx numerically](https://github.com/peeringdb/peeringdb/issues/656) | Fixes the sorting orer of user IDs, so they are now sorted in numerical order. |
 | [#881 wrap correctly on mobile](https://github.com/peeringdb/peeringdb/issues/881) | The ASN column on mobile view will show seven digits before wrapping the number. |
 | [#908 2FA Backup Tokens language doesn't seem correct](https://github.com/peeringdb/peeringdb/issues/908) | Fixes the backup tokens language for 2FA. |
-| [#916 To force or not to force www, that is a question](https://github.com/peeringdb/peeringdb/issues/916) | Forces https://www.peeringdb.com as the URL for PeeringDB, enabling other improvements. |
+| [#916 To force or not to force www, that is a question](https://github.com/peeringdb/peeringdb/issues/916) | Forces https://www.peeringdb.com as the URL for PeeringDB, enabling other improvements. Some clients will need to adjust their endpoints to use www.peeringdb.com. `curl` users will want to use the `-L` flag. |
 | [#1042 Long caching of deleted entries](https://github.com/peeringdb/peeringdb/issues/1042) | Fixes a problem where deleted objects continued to be returned because of cacheing. |
 | [#1117 Bad API keys need to return 401 just like a bad user/pass. Presently they return 200](https://github.com/peeringdb/peeringdb/issues/1117) | Fixes a problem where corrupt or expired or bogus API key simply resulted in an anonymous user session. |
 


### PR DESCRIPTION
This change adds the missing word "software" into the facility approval process