### PR TITLE
Use localhost to access dev site

### DIFF
--- a/docs/howto/run_development_container.md
+++ b/docs/howto/run_development_container.md
@@ -92,7 +92,7 @@ If you want a copy of the current *public* production data, run this command whi
 ./Ctl/dev/run.sh pdb_load_data --commit
 ```
 
-After it is done you should have a PeeringDB instance exposed on port `:8000`: [http://127.0.0.1:8000/](http://127.0.0.1:8000/)
+After it is done you should have a PeeringDB instance exposed on port `:8000`: [http://localhost:8000/](http://localhost:8000/)
 
 (should you want to change this port you can do so by setting the environment variable `DJANGO_PORT`)
 


### PR DESCRIPTION
When using 127.0.0.1 to access the dev instance, login fails with "CSRF cookie not set".  Logging in while accessing the site via localhost works fine.