### PR TITLE
docs(admincom): add AdminCom userscripts guide

### DIFF
--- a/docs/committee/admin/index.md
+++ b/docs/committee/admin/index.md
@@ -6,6 +6,8 @@
 ## Documentation
 
 - [Admin Committee Guidelines and Criteria for Approving Networks, IXPs, and Facilities](approval-guidelines)
+- [AdminCom Userscripts](userscripts/index.md) — browser tooling for the Control Panel, public
+  frontend, and DeskPro that streamlines day-to-day moderation work
 
 {!docs/committee/admin/charter.md!}
 

--- a/docs/committee/admin/userscripts/cp.md
+++ b/docs/committee/admin/userscripts/cp.md
@@ -1,0 +1,309 @@
+# CP — Consolidated Tools
+
+Runs on Control Panel (Django admin) change pages:
+`https://www.peeringdb.com/cp/peeringdb_server/*/*/change/*` (and the `beta.peeringdb.com`
+equivalent). This is the script AdminCom members spend the most time in — it covers Network,
+Facility, Internet Exchange, Carrier, Campus, Organization, and User review/edit workflows.
+
+See [Installing](index.md#installing) on the overview page if you haven't added this script yet.
+
+!!! tip "📸 Screenshot needed"
+    A CP network change page with the script active, wide enough to show the toolbar buttons and
+    the status/RIR badges near the page title — used as a general orientation shot at the top of
+    this page.
+
+## Update Name — the flagship feature
+
+The **Update Name** toolbar button (secondary action row, below the main toolbar) appears on
+every entity type. One click sets the entity's name from its parent organization (for
+Organization/Facility/IX pages, it normalizes the org's own name), then saves automatically.
+
+!!! tip "📸 Screenshot needed"
+    The "Update Name" button in the secondary action row, before clicking.
+
+What happens under the hood, in order:
+
+1. **Trading-as / DBA splitting.** A combined name like `Foo Corp, trading as Bar Networks`
+   is split into Name = `Bar Networks`, with `Foo Corp` routed into the **AKA** field and the
+   **Long Name** field.
+2. **Person / trade-name splitting** (for RIRs that use this convention, e.g. some LACNIC/
+   Guatemala registrations): a name like `EDWIN HERNÁNDEZ PEC (IMPORTADORA Y EXPORTADORA
+   INTERCEL)` is split into Name = the trade name, AKA = the person's name, Long Name = the
+   original combined string.
+3. **RDAP fallback for networks.** If the resulting name still looks like an auto-generated
+   handle (all-caps dashed tokens, `AS12345`-shaped strings, NIR registry prefixes like
+   `IDNIC-`/`AFRINIC-`), the script looks up the real registrant name via RDAP (using IANA's
+   RDAP bootstrap registry to find the right RIR) before giving up.
+4. **Housekeeping**: appends ` #<id>` to the name if the entity's status is `deleted` (keeps
+   duplicate names distinguishable in audits/history), and clears the deprecated "Floor" field
+   on facility-adjacent networks.
+5. **Auto-fixes a known validation error**: if the save fails because a POC's visibility is set
+   to the deprecated "Private" option, the script flips it to "Users" and retries.
+6. **Duplicate-name retry**: if the server rejects the name because another network already has
+   it, the script retries once with an ` (AS<asn>)` suffix appended.
+7. On success, redirects you straight to the entity's History page so you can see the diff.
+
+!!! tip "📸 Screenshot needed"
+    A before/after of the Name / AKA / Long Name fields on a network that went through the
+    trading-as or person/trade-name split.
+
+The button is intentionally disabled (with a toast explaining why) while an entity's status is
+`pending`, and for a small hard-coded list of "Example Organization" test records — so it can't
+accidentally rewrite a record still awaiting initial review, or corrupt the dummy/test org used
+for QA.
+
+### Configuring a keyboard shortcut
+
+Update Name can be bound to a keyboard combo so you don't have to scroll to the button on every
+record. From the Tampermonkey menu (click the extension icon while on a CP change page):
+
+1. Choose **`CP: Set Update Name Shortcut...`**.
+2. Enter a combo such as `Alt+U` or `Ctrl+Shift+N` when prompted. The combo **must** include
+   Ctrl, Alt, and/or Meta — Shift alone is rejected — so it can never fire while you're just
+   typing into a form field.
+3. The menu item relabels itself to confirm, e.g. **`CP: Update Name Shortcut [Alt+U]
+   (change...)`**. Choosing it again lets you change or clear the combo.
+
+Pressing the combo simply clicks the real button, so every check above (pending guard, dummy-org
+guard, retries) still applies exactly as if you'd clicked it yourself. No shortcut is set by
+default. Stored in `localStorage["pdbCpConsolidated.updateNameShortcut"]`.
+
+!!! tip "📸 Screenshot needed"
+    The Tampermonkey prompt for entering a shortcut combo, and the resulting relabeled menu item.
+
+## Network review & cleanup
+
+**Reset Information** — appears only on a **deleted** network's change page. Wipes nearly every
+editable field back to defaults (text/URL fields, prefix counters, checkboxes, social links,
+policy fields), re-derives the name from the organization (same RDAP fallback as Update Name),
+and auto-saves. Asks for confirmation first, naming the target network by ID/ASN/name.
+
+!!! tip "📸 Screenshot needed"
+    The "Reset Information" button and its confirmation dialog on a deleted network.
+
+**RIR/IRR status badges** — next to the page title on a network change page:
+a colored **RIR: `<status>`** badge (green = ok, red = invalid, orange = pending, gray = n/a)
+and, when available, an **IRR: `<as-set>`** badge. Hover for the last-updated date.
+
+!!! tip "📸 Screenshot needed"
+    The RIR/IRR badges next to a network's page title, ideally one green and one red/orange
+    example side by side.
+
+**Inline delete-row highlighting** — any inline row (POC, netfac, netixlan) with its **Delete**
+checkbox ticked gets a red-tinted background, so it's obvious what you're about to remove before
+you hit Save.
+
+!!! tip "📸 Screenshot needed"
+    An inline netixlan or POC row with the Delete checkbox ticked, showing the red highlight.
+
+A couple of quieter safety nets run in the background here too: stale `deleted`-status inline
+rows are automatically marked for real deletion on save, and deprecated "Private" POC visibility
+is normalized to "Users" so saves aren't rejected for a reason you didn't cause.
+
+## Internet Exchange / IX-F workflow
+
+**Request IXF Import** — toolbar button on an IX change page; triggers a fresh IX-F import via
+the API.
+
+**IXF status badge** — next to the IX page title: **IXF: `<status>`** (queued/importing =
+orange/blue, finished = green, error = red), hover for the last-import date. If the ixlan
+publishes a member list URL, a **Members** link appears alongside it.
+
+!!! tip "📸 Screenshot needed"
+    An IX change page showing the "Request IXF Import" button and the IXF status badge together.
+
+## IX-F & netixlan bulk tools (networkixlan changelist)
+
+These three tools live on the **networkixlan changelist** (list page, not a single record's
+change page) and are the most powerful — and most consequential — tools in the script. Use them
+deliberately; each requires an explicit confirmation before anything is written or deleted.
+
+### Audit IX-F Members
+
+Toolbar button **"Audit IX-F Members"**. Prompts for an ixlan ID if the page isn't already
+filtered to one, then fetches that ixlan's upstream IX-F member list and compares it against
+PeeringDB's netixlan rows, looking for cases where an IX-F member's IPv4 and IPv6 addresses are
+split across two separate PeeringDB rows that should really be one. Presents a table of
+candidates with **Re-scan**, **Apply merges**, and **Recent IP changes** actions. Merging keeps
+the older (lower-id) row and folds in the missing address, then removes the sibling row.
+
+!!! tip "📸 Screenshot needed"
+    The "IX-F Member Audit" modal with a populated candidate table.
+
+### Renumber IXLAN Peers
+
+Toolbar button that opens a modal for bulk-renumbering peers on an ixlan (old prefix → new
+prefix). It classifies every affected netixlan row as eligible / no-change / conflict / skipped,
+lets you review before applying, and calls out conflicts in a red banner. Typically launched via
+a link generated by the [DeskPro renumber tool](deskpro.md#ixlan-renumber-launcher) from a
+support ticket, rather than opened cold from CP.
+
+!!! tip "📸 Screenshot needed"
+    The "Renumber IXLAN Peers" modal showing a mix of eligible, conflict, and skipped rows.
+
+**Conflict resolution** (opened from inside the Renumber modal when conflicts exist) walks
+through a multi-step verification chain (matching ASN, matching ixlan, cross-checking the
+current IX-F member list, re-reading the row immediately before any delete) before letting you
+proceed, and only enables the delete action once you type the exact ixlan ID into a confirmation
+box. Nothing that would lose data is deleted without first merging in whatever fields the
+surviving row was missing.
+
+!!! tip "📸 Screenshot needed"
+    The conflict-resolution modal, especially the ixlan-ID confirmation box gating the delete
+    action.
+
+### Recent IP Changes
+
+A read-only report (reachable as its own toolbar button, or from inside either modal above)
+combining live API data with a local log of what the two tools above have done recently — useful
+for confirming "did that renumber/merge actually take effect" even after the live data has moved
+on. Output is plain text with a **Copy** button.
+
+!!! tip "📸 Screenshot needed"
+    The "Recent IP Changes" report window with a few example entries.
+
+## Copy & link helpers (all entity types)
+
+- **API JSON** — opens the entity's raw `/api/<resource>/<id>` response in a new tab.
+- **Copy `<Entity>` URL #`<id>`** — copies `Name | https://www.peeringdb.com/<slug>/<id>` to the
+  clipboard (label adapts per entity type: Network, Facility, Org, Carrier, IX, Campus).
+- **Copy Org URL #`<orgId>`** — same idea, for the parent organization.
+- **Copy User Profile URL #`<id>`** — on User pages.
+- A small **⧉** copy icon next to almost every rendered field value on the page (skips noisy
+  fields like logo/status/IX-F metadata). The **Prefixes** field additionally gets **BGP.HE** and
+  **BGP.TOOLS** links that open the prefix directly on those sites.
+- **`<Entity>` Website** / **Org Website** buttons that open the relevant Website field, reusing
+  the same browser tab on repeat clicks instead of spawning a new one each time.
+- **`<Entity>` (FP)** / **Org (FP)** / **Org (CP)** buttons for one-click cross-navigation to the
+  public frontend or the parent org's CP page. On an IX page with at least one ixlan, an
+  **IXLAN Prefix (CP)** button is added too. If the entity's own status isn't `ok`, the FP button
+  is shown disabled and relabeled to say so, rather than sending you to a page that 404s.
+- On `networkixlan` change pages specifically: **Org (CP)**, **Network (CP)**, **IX (CP)**
+  buttons for quick cross-navigation.
+
+!!! tip "📸 Screenshot needed"
+    A change page's secondary action row showing several of these buttons together (Copy URL,
+    Website, FP/CP cross-links), plus a close-up of the ⧉ copy icon next to a field.
+
+## Facility-specific helpers
+
+- **Maps** dropdown — Google Maps / Bing Maps / OpenStreetMap, built from lat/long if present,
+  otherwise the street address.
+- **Search (FP)** — deep-links to the public advanced search filtered by the facility's
+  country/state/zip, handy for spotting duplicate facility listings.
+
+!!! tip "📸 Screenshot needed"
+    The "Maps" dropdown open, showing its three map-provider options.
+
+## User / security lookups
+
+On a User change page:
+
+- **TOTP Device / Security Key** quick links (single button if there's one device, a dropdown
+  if there are several) — jump straight to that MFA device's own admin record.
+- **OTP Email** / **OTP Static** links — since those device types don't show inline on the User
+  page, these link to a username-filtered search on their respective changelists instead.
+- **Search Username** — deep-links to the email-address admin filtered by this user's username,
+  a quick way to see every email address tied to an account during an identity/security review.
+
+!!! tip "📸 Screenshot needed"
+    A User change page showing the MFA device quick-link buttons/dropdowns.
+
+## Visual state cues
+
+- **Status badges** on the page title: **PENDING** (orange) or **DELETED** (red) for any entity
+  in that state; **CHILD OF DUMMY ORGANIZATION** (red) specifically for a facility whose parent
+  org is the test/dummy organization. These update live if you change the Status or Org dropdown
+  without reloading.
+- **Window/tab titles** are rewritten to something identifiable — e.g.
+  `PDB CP | NETWORK | Name | Country` — so it's easy to tell CP tabs apart when you have several
+  open.
+- **History page timestamps** are rewritten from ambiguous 12-hour form ("Sept. 26, 2025,
+  10:42 p.m.") to unambiguous 24-hour ISO form, with the original kept as a hover tooltip.
+
+!!! tip "📸 Screenshot needed"
+    A pending or deleted entity showing its status badge and background tint near the page title.
+
+## List-page (changelist) diagnostics
+
+- **Analyze Network Names** — on the Network changelist, bulk-scans network names looking for
+  ones that appear auto-generated or placeholder (numeric-only, `ASxxxxx`-shaped, NIR registry
+  prefixes, "test"/"dummy" keywords, etc.), and copies a worklist (with a link to each record's
+  change page) to the clipboard for follow-up.
+- **Copy Change Links** — on any entity's changelist, copies every visible row's `/change/` URL
+  from the current filtered/paginated view, one per line — useful for building a batch of links
+  to review or paste into a ticket.
+
+!!! tip "📸 Screenshot needed"
+    The Network changelist toolbar showing the "Analyze Network Names" button, mid-scan
+    ("Scanning 3/6" or similar progress text) if possible.
+
+## Approvals
+
+**Approve** / **Reject** buttons on a CarrierFacility change page, calling the corresponding API
+endpoint directly.
+
+!!! tip "📸 Screenshot needed"
+    The Approve/Reject buttons on a CarrierFacility change page.
+
+## Tampermonkey menu commands
+
+Commands that mirror an on-page button (only appear when that button exists on the current
+page):
+
+- `CP: Update Name`
+- `CP: Copy Entity URL`
+- `CP: Copy User Profile URL`
+- `CP: Copy Org URL`
+- `CP: Reset Information`
+
+Always-available commands:
+
+- `CP: Set Update Name Shortcut...`
+- `CP: Clear Org Name Cache`
+- `CP: Clear RDAP Cache`
+- `CP: Debug Mode [ON/OFF] (toggle to ON/OFF)`
+- `CP: Log User-Agent (Debug ON/OFF)`
+- `CP: Feature Flags (show in console)`
+- `CP: Feature Flags (reset overrides)`
+- `CP: Feature <flagName> [ON/OFF]` — one toggle per advanced feature flag (see below)
+
+## Configuration
+
+### Disabling individual modules
+
+Set `localStorage["pdbCpConsolidated.disabledModules"]` to a JSON array or comma-separated
+string of module IDs, then reload the page:
+
+```js
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["reset-network-information"]');
+```
+
+Module IDs used above, for reference: `set-entity-name-equal-org-name`, `reset-network-information`,
+`network-rir-status-badge`, `ixf-import-status-badge`, `request-ixf-import`,
+`ixlan-renumber-peers`, `ix-f-member-audit`, `recent-ip-changes`, `copy-frontend-urls`,
+`copy-rendered-field-values`, `entity-website-header-links`, `frontend-links`,
+`facility-google-maps`, `facility-advanced-search-link`, `user-mfa-device-quick-links`,
+`search-user-email-by-username`, `entity-state-visuals`, `set-window-title`,
+`history-24h-timestamps`, `network-name-pattern-diagnostics`, `copy-overview-change-links`,
+`carrierfac-approve-reject`, `inline-delete-row-highlights`.
+
+### Advanced feature flags
+
+A separate mechanism gates the riskier netixlan bulk tools (all default **on**); manage these
+via the Tampermonkey menu commands rather than editing localStorage directly:
+`ixlanRenumber`, `ixfMemberAudit`, `conflictResolver`, `recentIpChanges`, `orgUpdateAuditLog`,
+`moduleDispatch`, `debugMode`.
+
+### Debug mode
+
+See [Debug mode](index.md#debug-mode) on the overview page — shared with FP and DP.
+
+## Troubleshooting
+
+- **A button/badge you expect isn't showing up** — check you're not on a `pending` entity for
+  Update Name, or a non-`deleted` one for Reset Information; both are intentionally gated.
+- **One feature is misbehaving but the rest work fine** — disable just that module (see
+  Configuration above) rather than the whole script, and file an issue with the module ID.
+- **Something feels stale/cached** — `CP: Clear Org Name Cache` and `CP: Clear RDAP Cache` reset
+  the two caches this script keeps for name-normalization lookups.

--- a/docs/committee/admin/userscripts/deskpro.md
+++ b/docs/committee/admin/userscripts/deskpro.md
@@ -1,0 +1,144 @@
+# DeskPro — Consolidated Tools
+
+Runs inside DeskPro (`https://peeringdb.deskpro.com/app*`), the support desk AdminCom uses for
+network/IX/facility/carrier approval requests, ownership/affiliation requests, and IXLAN
+renumbering tickets. Unlike the CP and FP scripts, this one isn't built from small toggleable
+modules — it's a set of always-on ticket enrichments plus two opt-in workflow launchers gated by
+feature flags.
+
+See [Installing](index.md#installing) on the overview page if you haven't added this script yet.
+
+## Automatic ticket enrichment
+
+All of the following happens automatically as you read a ticket — nothing to click, and it never
+touches text you're actively typing in the composer.
+
+### ASN mentions become links
+
+Text like `AS12345`, `ASN12345`, `member ASN: 12345`, or a bare standalone number in a context
+that's clearly about an ASN (near IPv4/IPv6 addresses, in a member-table block, or right after a
+line mentioning "ASN") is turned into a link to that ASN's PeeringDB page, with the PeeringDB
+favicon appended.
+
+The link's label and tooltip then fill in progressively in the background: first with the
+resolved network name (`AS12345 (Example Network)`), then — if it resolves — a multi-line
+tooltip with the org name and POC list.
+
+!!! tip "📸 Screenshot needed"
+    A ticket body with an ASN mention rendered as a link with the small favicon, then a follow-up
+    screenshot showing the multi-line tooltip (network name / org / POCs) after it finishes
+    loading.
+
+### Organization names become search links
+
+Text matching `wishes to be affiliated to Organization 'Org Name'` (any quote style) turns the
+quoted org name into a link to a PeeringDB search for that name — handy for immediately checking
+whether the org already exists before approving an affiliation request.
+
+!!! tip "📸 Screenshot needed"
+    An affiliation-request ticket with the quoted org name rendered as a search link.
+
+### Existing PeeringDB links get smarter tooltips
+
+Any `peeringdb.com` link already present in a ticket (pasted by a requester, or rendered by
+DeskPro itself) gets its tooltip enriched on hover — for example, a `net/1234` link's tooltip
+becomes `net/1234 | <name> | AS<asn> | Org <org name> | POCs <role (email), ...>`, and a CP
+change-page link's tooltip names the object type and ID. If the linked object turns out to be
+missing from the public frontend (e.g. still pending review), the link is silently redirected to
+the equivalent CP change page instead of leading to a dead end.
+
+!!! tip "📸 Screenshot needed"
+    Hovering an existing `net/1234` (or similar) link in a ticket, showing the enriched tooltip.
+
+### Email addresses get copy/search helpers
+
+Every `mailto:` link in a ticket is decorated with a 📋 (copy) and 🔍 (search-by-email-in-CP)
+affordance. Clicking the email text itself copies the address to the clipboard (rather than
+opening a mail client) and briefly flashes "Copied: `<email>`" as confirmation.
+
+!!! tip "📸 Screenshot needed"
+    A ticket contact row showing an email address with its 📋 and 🔍 icons, and a follow-up shot
+    of the "Copied: ..." tooltip right after clicking.
+
+### Malformed CP links are fixed automatically
+
+Any link containing the double-slash typo `peeringdb.com//cp/peeringdb_server` is silently
+corrected to the proper single-slash form. Not visually distinctive — nothing to screenshot here.
+
+## Whitelist CMD Generator
+
+Menu command: **`DP: Generate Whitelist CMD`**. Use this while reviewing an IX / Network /
+Facility / Carrier approval (or `[SUGGEST]`) ticket that contains a link to that object's CP
+change page.
+
+1. Run the command from the Tampermonkey menu while the ticket tab is active.
+2. The script finds every PeeringDB object referenced in the ticket, fetches each one live from
+   the API (deliberately without caching, so a still-pending object shows up correctly rather
+   than as a stale miss), and opens a **Whitelist CMD Generator** modal.
+3. If more than one object was found, pick the right one from the dropdown.
+4. Confirm or edit the pre-filled **Hostname** field (taken from the object's website).
+5. The modal shows the exact domains that will be whitelisted (the hostname, its apex domain, and
+   the `www.` variant) and the ready-to-run command, e.g.:
+
+   ```
+   pihole allow "example.com" "www.example.com" --comment "PeeringDB DeskPro ticket 12345 - Internet Exchange Request"
+   ```
+
+6. Click **Copy** and paste the command into your pihole/ad-blocker admin.
+
+!!! tip "📸 Screenshot needed"
+    The full "Whitelist CMD Generator" modal with a populated hostname, candidate domains, and
+    generated command.
+
+## IXLAN Renumber launcher
+
+Menu command: **`DP: Renumber IXLAN Peers`**. Use this on a renumbering ticket that mentions an
+old and new prefix (any of `->`, `=>`, `→`, or the word "to" between them, for IPv4 and/or IPv6
+independently).
+
+1. Run the command while the ticket tab is active.
+2. The script scans the ticket for old→new prefix pairs and for a CP `ixlan/{id}/change/` link,
+   pre-filling a confirmation modal with whatever it found.
+3. Review and edit the IPv4/IPv6 old/new fields and the ixlan ID as needed.
+4. Click **Open in CP** — this opens the CP networkixlan changelist with the reviewed values
+   encoded in the page's URL fragment, which the [CP script's Renumber IXLAN Peers
+   tool](cp.md#renumber-ixlan-peers) reads to pre-populate its own confirmation view.
+
+This launcher never modifies PeeringDB data itself — it only detects the prefix pair, lets you
+confirm or correct it, and hands off to CP, where the actual renumbering (with its own review and
+confirmation step) happens.
+
+!!! tip "📸 Screenshot needed"
+    The "Renumber IXLAN Peers" confirmation modal with pre-filled old/new IPv4 and/or IPv6 rows.
+
+## Menu commands
+
+- `DP: Debug Mode [ON/OFF] (toggle to ON/OFF)`
+- `DP: Feature Flags (show)` / `DP: Feature Flags (reset)`
+- `DP: <flagName> [ON/OFF]` — one per flag (`whitelistCmdGenerator`, `ixlanRenumber`)
+- `DP: Generate Whitelist CMD` — only present while `whitelistCmdGenerator` is enabled
+- `DP: Renumber IXLAN Peers` — only present while `ixlanRenumber` is enabled
+
+!!! note
+    Toggling `whitelistCmdGenerator` or `ixlanRenumber` takes effect on the **next page load** —
+    the corresponding menu command isn't added or removed live.
+
+## Configuration
+
+Both workflow launchers default to **on**. Toggle them from the Tampermonkey menu, or directly:
+
+```js
+localStorage.setItem("pdbDp.featureFlags", JSON.stringify({ ixlanRenumber: false }));
+```
+
+### Debug mode
+
+See [Debug mode](index.md#debug-mode) on the overview page — shared with CP and FP.
+
+## Troubleshooting
+
+- **Neither launcher command shows up in the Tampermonkey menu** — reload the DeskPro tab after
+  changing a feature flag; the commands are only (re-)registered at page load.
+- **Whitelist Generator says no PeeringDB object was found** — it only looks at CP change-page
+  links currently visible in the active ticket tab; make sure the relevant link is in the ticket
+  body and that ticket's tab is the foregrounded one.

--- a/docs/committee/admin/userscripts/fp.md
+++ b/docs/committee/admin/userscripts/fp.md
@@ -1,0 +1,162 @@
+# FP — Consolidated Tools
+
+Runs on the public PeeringDB frontend: `https://www.peeringdb.com/*` (and `beta.peeringdb.com`),
+excluding `/cp/*`. This is the script that's active while you're browsing org/network/facility/
+IX/carrier/campus pages and user-manager panels as a regular visitor would, but with AdminCom
+shortcuts layered on top.
+
+See [Installing](index.md#installing) on the overview page if you haven't added this script yet.
+
+## Background fixes (no button, nothing to see)
+
+Two small things happen automatically, silently, on every page load:
+
+- A malformed URL with a double slash (`//`) is corrected via a redirect.
+- An ASN page that renders as a public "404 Not Found" (because the network isn't visible on the
+  frontend, e.g. still pending) redirects you straight to the equivalent CP search by ASN,
+  saving a manual re-search.
+
+## Page identity & navigation
+
+**Window/tab titles** are rewritten to something identifiable on entity pages — e.g.
+`PDB | NET | as65000 (Example Corp) (a.k.a. Foo) | net.peeringdb.com` — useful when you have many
+tabs open during a review session. Cosmetic only, no screenshot needed.
+
+**CP link in the navbar** — a one-click jump straight to the CP root (`/cp/`) is added to the top
+navigation bar itself, in both the desktop-expanded and mobile-collapsed variants.
+
+!!! tip "📸 Screenshot needed"
+    The top navbar showing the added "CP" link, in both desktop-expanded and mobile-collapsed
+    form.
+
+## Entity page toolbar
+
+**CP (`<type>:<id>`)** — a top-right toolbar button on any entity page (network/ASN/org/
+facility/carrier/IX) that opens the record's CP change page directly in a new tab. Links that
+open a CP page in a new tab are automatically marked with a small 🛠↗ suffix so it's clear where
+they lead before you click.
+
+!!! tip "📸 Screenshot needed"
+    An entity page's top-right toolbar showing the "CP (net:1234) 🛠↗" button.
+
+On network/ASN pages specifically, two more one-click copy buttons appear — **Copy AS`<N>`**
+and **Copy Net Summary** (`AS<asn> | <name> | net_id <id> | <url>`) — plus a **More Tools**
+overflow menu with quick external lookups for that ASN: BGP.TOOLS, BGP.HE, RIPEstat, BGPView,
+CIDR Report, IPinfo, Cloudflare Radar, RouteViews, and the raw PeeringDB API response.
+
+!!! tip "📸 Screenshot needed"
+    The "More Tools" dropdown open on a network page, showing the full list of external lookups.
+
+**Copy URL** — on any entity page, copies `<entity name> | <page URL>` to the clipboard, handy
+for pasting record references into tickets or chat.
+
+## Admin Ops toolkit (opt-in, off by default)
+
+This is the richest feature set in the script, but it's hidden until you turn on **Admin Ops
+Mode** — nothing described in this section appears otherwise.
+
+Enable it via the Tampermonkey menu command **`FP: Admin Ops Mode [OFF] (toggle to ON)`** (it
+relabels itself to confirm once on). When enabled, entity pages gain an **Open API** button and
+an **Admin Ops** overflow menu whose contents adapt to the entity type and available data:
+
+| Item | Shows when | What it does |
+|---|---|---|
+| Open CP Org | Non-org entity with a resolvable parent org | Opens the parent org's CP page. |
+| Open CP User Manager | Parent org resolvable | Opens the parent org's CP page, jumped to the user-manager section. |
+| Copy Entity IDs | Always | Copies a compact `type=…; id=…; org_id=…; asn=…; …` reference line. |
+| Copy Triage Summary | Always | Copies a multi-line summary (type, id, name, org, ASN, website, IRR AS-SET, traffic, URL) ready to paste into a ticket. |
+| CP Search Pack | Always | Builds and opens CP account-email search links from the entity's name/ASN/visible org-user info (asks first if it would open more than a couple of tabs). |
+| Open Related Objects | Related netixlan/netfac/POC rows visible | Opens those related records' pages, plus the parent org. |
+| Email Domain Inspector | Org pages | Tallies the email domains among visible org users and copies a domain→count report — a quick signal for anomalies (one org, many unrelated domains). |
+| Validate External Links | Always | Checks up to 8 visible external links (e.g. website) for HTTP errors and copies a status report. |
+| Compare UI vs API | Always | Diffs what's rendered on the page against the same fields from the live API, to catch stale/cached rendering. |
+| Prefix Sanity Check | Network pages | Flags implausible IPv4/IPv6 prefix counts (negative, or unrealistically high). |
+| Suspicious Signals | Always | A quick automated triage checklist: missing/short name, missing website, missing ASN or IRR AS-SET, an org with no visible user emails, or an org whose users span several distinct email domains. |
+| Audit Trail Jump | Always | Opens the CP changelist for this entity type, pre-filtered by ID. |
+| Soft Reset Form | Always | Clears leftover error/loading states from in-page edits — no data changes. |
+
+Everything in this menu either copies text to the clipboard or opens tab(s) — nothing renders
+inline on the page except the menu itself.
+
+!!! tip "📸 Screenshot needed"
+    The "Admin Ops" dropdown open on an org page, showing the full conditional item list.
+
+## Org page enhancements
+
+**User-manager row icons** — in the "Users You Can Manage" panel and pending-affiliation-request
+list, every row gains:
+
+- 🔍 next to the username — searches CP's account-email admin by username.
+- 🪪 next to the username (active users only) — opens that user's CP record directly.
+- 🔍 next to each email — searches CP by that email.
+- 📋 next to each email — copies it to the clipboard.
+- 📋 next to any ASN a requester mentioned in their affiliation request text — copies just the
+  digits.
+- A compact 🔐 icon replacing the host UI's bulkier 2FA badge.
+
+An **Admin 📧** button near the user-manager's submit button copies the email addresses of the
+org's **admin**-role users (not members) to the clipboard in one click.
+
+!!! tip "📸 Screenshot needed"
+    An org's user-manager row showing the 🔍/🪪/📋/🔐 icon cluster next to a username and email,
+    plus the "Admin 📧" button near the submit button.
+
+**CP edit shortcuts on related-object listings** — every row in an org's Facility, Network,
+Internet Exchange, Carrier, and Campus listings gets a small ⚙️ gear-icon link on the right,
+opening that specific record's CP change page directly. Applies to every row regardless of
+status.
+
+!!! tip "📸 Screenshot needed"
+    An org page's Facility (or Network/IX/Carrier/Campus) listing row with the ⚙️ gear icon
+    visible on the right edge.
+
+**CP edit shortcuts on OAuth applications** — in the "Manage OAuth Applications" panel, a
+**CP (oauth:`<id>`)** button appears next to each application's existing "Details" button,
+linking to that application's CP change page.
+
+!!! tip "📸 Screenshot needed"
+    The OAuth Applications panel showing the new "CP (oauth:…)" button next to "Details".
+
+## Tampermonkey menu commands
+
+- `FP: Copy URL` / `FP: Copy AS<N>` — click the page's own copy button, if present.
+- `FP: Open Admin Console` — opens the current page's CP link, if present.
+- `FP: Admin Ops Mode [ON/OFF] (toggle to ON/OFF)` — the switch for the whole Admin Ops toolkit.
+- `FP: Debug Mode [ON/OFF] (toggle to ON/OFF)`
+- `FP: Log User-Agent (Debug ON/OFF)`
+- `FP: Feature Flags (show in console)` / `FP: Feature Flags (reset overrides)`
+- `FP: Feature <flagName> [ON/OFF]` — one per flag (`adminOpsMode`, `debugMode`,
+  `moduleDispatch`).
+
+## Configuration
+
+### Disabling individual modules
+
+```js
+localStorage.setItem("pdbFpConsolidated.disabledModules", '["copy-user-roles"]');
+```
+
+Module IDs: `fix-double-slashes`, `asn-404-cp-search-redirect`, `set-window-title`,
+`navbar-cp-link`, `admin-console-link`, `copy-record-data`, `admin-workflow-buttons`,
+`copy-user-roles`, `org-related-listing-cp-edit-links`, `org-oauth-cp-edit-links`.
+
+### Admin Ops Mode
+
+The practical on/off switch for the toolkit in that section above — toggle it via the
+Tampermonkey menu command, or directly:
+
+```js
+localStorage.setItem("pdbFpConsolidated.adminOpsMode", "1");   // on
+localStorage.removeItem("pdbFpConsolidated.adminOpsMode");     // off
+```
+
+### Debug mode
+
+See [Debug mode](index.md#debug-mode) on the overview page — shared with CP and DP.
+
+## Troubleshooting
+
+- **Admin Ops menu isn't showing up** — it's opt-in; confirm `adminOpsMode` is enabled (see
+  above) and reload the page.
+- **One feature is misbehaving but the rest work fine** — disable just that module (see
+  Configuration above) rather than the whole script, and file an issue with the module ID.

--- a/docs/committee/admin/userscripts/index.md
+++ b/docs/committee/admin/userscripts/index.md
@@ -1,0 +1,89 @@
+# AdminCom Userscripts
+
+The Admin Committee maintains three browser userscripts that streamline day-to-day moderation
+work across the three tools AdminCom members actually use: the PeeringDB Control Panel, the
+public PeeringDB site, and the DeskPro support desk. Source lives in the
+[`peeringdb/admincom`](https://github.com/peeringdb/admincom) repository, under `user.js/`.
+
+| Script | Runs on | Guide |
+|---|---|---|
+| **CP — Consolidated Tools** | `peeringdb.com/cp/peeringdb_server/*/*/change/*` (Control Panel change pages) | [CP guide](cp.md) |
+| **FP — Consolidated Tools** | `peeringdb.com/*` (public frontend, excluding `/cp/`) | [FP guide](fp.md) |
+| **DP — Consolidated Tools** | `peeringdb.deskpro.com/app*` (DeskPro support desk) | [DeskPro guide](deskpro.md) |
+
+!!! tip "📸 Screenshot needed"
+    A composite or three side-by-side screenshots showing each script's Tampermonkey icon/badge
+    active in the browser toolbar on its respective site (CP change page, a public entity page,
+    and a DeskPro ticket).
+
+## Installing
+
+1. Install the [Tampermonkey](https://www.tampermonkey.net/) browser extension.
+2. Open the `.meta.js` URL for the script you want (Tampermonkey will offer to install it, and
+   will check this URL periodically for updates):
+    - CP: `https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-cp-consolidated-tools.meta.js`
+    - FP: `https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-fp-consolidated-tools.meta.js`
+    - DeskPro: `https://raw.githubusercontent.com/peeringdb/admincom/master/user.js/peeringdb-deskpro-tools.meta.js`
+3. Confirm the install prompt. Tampermonkey pulls the matching `.user.js` file automatically.
+
+You only need to install the scripts that match tools you actually use — for example, if you
+never touch DeskPro, you can skip the DP script entirely.
+
+!!! tip "📸 Screenshot needed"
+    The Tampermonkey "Install this script?" confirmation dialog for one of the three scripts.
+
+## Concepts shared across all three scripts
+
+These scripts were built together and share a few conventions worth knowing before diving into
+the per-script guides.
+
+### Modules and feature flags
+
+Each script is broken into small, independently-toggleable **modules** (CP has 27, FP has 10;
+the DeskPro script uses a smaller set of **feature flags** instead of modules — see its guide).
+If one feature misbehaves, you don't have to disable the whole script — just that module, from
+the browser console (F12 → Console tab):
+
+```js
+// CP: disable a single module
+localStorage.setItem("pdbCpConsolidated.disabledModules", '["reset-network-information"]');
+
+// FP: disable a single module
+localStorage.setItem("pdbFpConsolidated.disabledModules", '["copy-user-roles"]');
+
+// Re-enable everything again
+localStorage.removeItem("pdbCpConsolidated.disabledModules");
+localStorage.removeItem("pdbFpConsolidated.disabledModules");
+```
+
+Reload the page after changing this for it to take effect. The per-script guides list every
+module ID you can use here.
+
+### Tampermonkey menu commands
+
+Every script registers commands under its Tampermonkey icon (visible when you're on a page the
+script runs on) — click the Tampermonkey toolbar icon, then the script's name, to see the list.
+Commands include things like debug-mode toggles and, for CP, the flagship "Update Name" shortcut
+configuration.
+
+!!! tip "📸 Screenshot needed"
+    The Tampermonkey extension menu open, showing one script's list of registered commands.
+
+### Debug mode
+
+All three scripts share one debug-logging switch. Turning it on (via any script's `Debug Mode`
+Tampermonkey menu command, or directly with the snippet below) enables verbose console logging
+for all of them at once, since CP and FP share an origin (`peeringdb.com`) and DP has its own
+copy scoped to `peeringdb.deskpro.com`:
+
+```js
+localStorage.setItem('pdbAdmincom.debug', '1');
+```
+
+Turn it back off the same way (`'0'` or remove the key) once you're done diagnosing an issue —
+it's noisy in normal use.
+
+### Reporting problems
+
+File an issue at [peeringdb/admincom](https://github.com/peeringdb/admincom/issues) — every
+script's Tampermonkey `@supportURL` points there too.


### PR DESCRIPTION
Add a documentation guide covering the three Tampermonkey userscripts AdminCom relies on for day-to-day moderation (Control Panel, public frontend, and DeskPro), grounded directly in the current source rather than the stale internal README. Screenshot placement is marked inline so reviewers can capture and add images before this is merged.

Changes:
- docs/committee/admin/userscripts/index.md: install steps and shared concepts (module disable list, feature flags, debug mode)
- docs/committee/admin/userscripts/cp.md: full Control Panel guide covering all 27 modules, menu commands, and configuration
- docs/committee/admin/userscripts/fp.md: full frontend guide covering all 10 modules, menu commands, and configuration
- docs/committee/admin/userscripts/deskpro.md: ticket enrichment, Whitelist CMD Generator, and IXLAN Renumber launcher
- docs/committee/admin/index.md: link to the new guide

Security:
- Documentation only, no code or access changes
- Publishes internal tooling detail (including the destructive netixlan renumber/conflict-resolver tools) to a public docs site; flagged for maintainer review before merge given the operational detail involved

Testing:
- No local mkdocs/uv install available to run a full site build
- Manually verified markdown structure (admonition indentation, link syntax) with a script pass over the new files

Backwards Compatibility:
- Additive only; no existing pages, nav entries, or links were changed besides the new "AdminCom Userscripts" link on the admin index page