### PR TITLE
docs: document API key authentication on API specs page

### DIFF
--- a/docs/api_specs.md
+++ b/docs/api_specs.md
@@ -51,7 +51,13 @@ JSON
 
 #### Authentication
 
+- API key, sent in the `Authorization` header as `Authorization: Api-Key <KEY>` (recommended)
 - Basic HTTP authorization
+
+An API key is required for write operations (`POST`, `PUT`, `DELETE`). Basic
+HTTP authorization is still accepted for read queries, but moving to an API key
+is strongly recommended. See our [guide on API keys](/howto/api_keys/) for how
+to create and use one.
 
 In order to access the API as a guest simply omit any authentication
 


### PR DESCRIPTION
The API Specs page only listed Basic HTTP authorization, so readers had no indication that API keys are the supported and recommended way to authenticate (and that writes require one). This adds the `Authorization: Api-Key <KEY>` header to the authentication section and links to the existing API keys guide, matching the wording already used in the how-to and the API-keys blog posts.

Fixes peeringdb/peeringdb#2010