### PR TITLE
feat(docs): add fork-preview banner, dual Atom feeds, gh-pages reset

### DIFF
--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -1,0 +1,31 @@
+name: Docs Build Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - admincom/docs-improvements
+
+permissions:
+  contents: read
+
+jobs:
+  build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Build docs (strict)
+        run: uv run mkdocs build --strict

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -43,7 +43,7 @@ jobs:
       # as a repo variable (Settings -> Secrets and variables -> Actions ->
       # Variables -> SITE_URL_OVERRIDE) rather than hardcoded here, so it can be
       # changed without editing this file. It feeds both scripts/generate_cname.py
-      # (writes docs/CNAME) and scripts/generate_atom_feed.py (the feed's
+      # (writes docs/CNAME) and scripts/generate_blog_atom_feed.py (the feed's
       # self-link), so both stay in sync with wherever this deploy actually serves
       # from. Safe by default if this branch is ever merged upstream: with no
       # variable set there, both hooks fall back to mkdocs.yml's site_url

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy Docs Preview
+
+on:
+  push:
+    branches:
+      - master
+      - admincom/docs-improvements
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Strip production CNAME before building (fork preview must not claim docs.peeringdb.com)
+        run: rm -f docs/CNAME
+
+      - name: Configure git identity for the gh-deploy commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy to gh-pages
+        run: uv run mkdocs gh-deploy --clean --force

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -40,4 +42,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy to gh-pages
+        env:
+          ATOM_SITE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
         run: uv run mkdocs gh-deploy --clean --force

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -51,4 +51,4 @@ jobs:
       - name: Deploy to gh-pages
         env:
           SITE_URL_OVERRIDE: ${{ vars.SITE_URL_OVERRIDE }}
-        run: uv run mkdocs gh-deploy --clean --force
+        run: uv run mkdocs gh-deploy --clean --force --no-history

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -33,15 +33,22 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
 
-      - name: Strip production CNAME before building (fork preview must not claim docs.peeringdb.com)
-        run: rm -f docs/CNAME
-
       - name: Configure git identity for the gh-deploy commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # This fork's preview serves at a dedicated dev domain, docs-dev.peeringdb.dk,
+      # distinct from upstream production's docs.peeringdb.com. The domain is set
+      # as a repo variable (Settings -> Secrets and variables -> Actions ->
+      # Variables -> SITE_URL_OVERRIDE) rather than hardcoded here, so it can be
+      # changed without editing this file. It feeds both scripts/generate_cname.py
+      # (writes docs/CNAME) and scripts/generate_atom_feed.py (the feed's
+      # self-link), so both stay in sync with wherever this deploy actually serves
+      # from. Safe by default if this branch is ever merged upstream: with no
+      # variable set there, both hooks fall back to mkdocs.yml's site_url
+      # (docs.peeringdb.com), so no manual CNAME edit is needed at merge time.
       - name: Deploy to gh-pages
         env:
-          ATOM_SITE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
+          SITE_URL_OVERRIDE: ${{ vars.SITE_URL_OVERRIDE }}
         run: uv run mkdocs gh-deploy --clean --force

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ site/
 venv/
 .venv/
 docs/blog/atom.xml
+docs/release_notes/atom.xml
 docs/CNAME
 __pycache__/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ site/
 venv/
 .venv/
 docs/atom.xml
+docs/CNAME
 __pycache__/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ site/
 .DS_Store
 venv/
 .venv/
-docs/atom.xml
+docs/blog/atom.xml
 docs/CNAME
 __pycache__/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ site/
 .DS_Store
 venv/
 .venv/
+docs/atom.xml
+__pycache__/
+*.pyc

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-docs.peeringdb.com

--- a/docs/blogs.md
+++ b/docs/blogs.md
@@ -2,6 +2,8 @@
 
 PeeringDB blogs provide deeper insight into the releases and product roadmap.
 
+Subscribe via [Atom feed](atom.xml) to get notified of new posts.
+
 ## 2026
 - [Do We Still Need Public Beta?](blog/public_beta.md) - July 26, 2026
 - [Data Quality for Networks](blog/data_quality_for_networks.md) - July 1, 2026

--- a/docs/blogs.md
+++ b/docs/blogs.md
@@ -2,7 +2,7 @@
 
 PeeringDB blogs provide deeper insight into the releases and product roadmap.
 
-Subscribe via [Atom feed](atom.xml) to get notified of new posts.
+Subscribe via [Atom feed](blog/atom.xml) to get notified of new posts.
 
 ## 2026
 - [Do We Still Need Public Beta?](blog/public_beta.md) - July 26, 2026

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -170,3 +170,45 @@ a:hover {
   color: #00203e;
   background-color: #f1f1f1;
 }
+
+/* 3.5rem matches the nav bar's own documented height (see mkdocs's base.css:
+   `scroll-padding-top: calc(3.5rem + 20px)`), which is exactly what .nav-link's
+   1rem top + 1rem bottom padding plus Bootstrap's 1.5rem default line-height add
+   up to. Setting the banner to the same value keeps it visually equal-height
+   without measuring anything at runtime. */
+.fork-banner {
+  background-color: #e6e6fa;
+  color: #ff69b4;
+  font-family: "Comic Sans MS", "Comic Sans", cursive;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5rem;
+  font-size: 1.1rem;
+  padding: 0 8px;
+  box-sizing: border-box;
+  overflow: hidden;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1031; /* above Bootstrap's .navbar.fixed-top (1030), so it stays on top when both stick */
+}
+
+/* The nav bar normally sticks at the very top (base.css's .navbar.fixed-top
+   override). With the banner also stuck at top:0 above it, offset the nav down
+   by the banner's own height so they stack together instead of overlapping. */
+body.has-fork-banner .navbar.fixed-top {
+  top: 3.5rem;
+}
+
+.fork-banner-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.fork-banner a {
+  color: #ff1493;
+  text-decoration: underline;
+}

--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -4,6 +4,8 @@ The release notes list the GitHub issues and a summary of what has changed in Pe
 
 Each new release has a one week beta test period on the [beta server](https://beta.peeringdb.com/) before it goes live.  The beta and new releases are announced on the [PeeringDB Announce Mailing List](https://lists.peeringdb.com/cgi-bin/mailman/listinfo/pdb-announce) and on [Facebook](https://www.facebook.com/peeringdb), [LinkedIn](https://www.linkedin.com/company/peeringdb) and [X](https://x.com/PeeringDB).
 
+Subscribe via [Atom feed](atom.xml) to get notified of new releases.
+
 ## Release schedule
 
 This schedule provides planned dates for PeeringDB’s future releases. We are sharing these dates to help PeeringDB users plan ahead for testing new and improved features in beta. We also want to help volunteer developers know the date on which their code changes are needed for internal testing before beta release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: https://docs.peeringdb.com/
 
 hooks:
   - scripts/generate_blog_atom_feed.py
+  - scripts/generate_release_notes_atom_feed.py
   - scripts/generate_cname.py
   - scripts/generate_banner.py
 # This line adds the "Edit on GitHub" link

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: PeeringDB Docs
 site_url: https://docs.peeringdb.com/
 
 hooks:
-  - scripts/generate_atom_feed.py
+  - scripts/generate_blog_atom_feed.py
   - scripts/generate_cname.py
   - scripts/generate_banner.py
 # This line adds the "Edit on GitHub" link

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: https://docs.peeringdb.com/
 
 hooks:
   - scripts/generate_atom_feed.py
+  - scripts/generate_cname.py
 # This line adds the "Edit on GitHub" link
 #repo_url: https://github.com/peeringdb/docs
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: PeeringDB Docs
 site_url: https://docs.peeringdb.com/
+
+hooks:
+  - scripts/generate_atom_feed.py
 # This line adds the "Edit on GitHub" link
 #repo_url: https://github.com/peeringdb/docs
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://docs.peeringdb.com/
 hooks:
   - scripts/generate_atom_feed.py
   - scripts/generate_cname.py
+  - scripts/generate_banner.py
 # This line adds the "Edit on GitHub" link
 #repo_url: https://github.com/peeringdb/docs
 theme:

--- a/peeringdb_theme/base.html
+++ b/peeringdb_theme/base.html
@@ -1,0 +1,235 @@
+<!-- Full copy of mkdocs 1.4.3's built-in themes/mkdocs/base.html (pinned version,
+     see pyproject.toml), plus one insertion: the fork-preview banner immediately
+     before the navbar div. There's no block wrapping that div in the upstream
+     template, so overriding just main.html can't reach above the nav bar -- this
+     whole file had to be duplicated. If mkdocs is ever upgraded, re-diff against
+     the new packaged base.html and re-apply this insertion. -->
+<!DOCTYPE html>
+<html lang="{{ config.theme.locale|default('en') }}">
+    <head>
+      {%- block site_meta %}
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        {% if page and page.is_homepage %}<meta name="description" content="{{ config['site_description'] }}">{% endif %}
+        {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
+        {% if page and page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
+        {% if config.site_favicon %}<link rel="shortcut icon" href="{{ config.site_favicon|url }}">
+        {% else %}<link rel="shortcut icon" href="{{ 'img/favicon.ico'|url }}">{% endif %}
+      {%- endblock %}
+
+      {%- block htmltitle %}
+        <title>{% if page and page.title and not page.is_homepage %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
+      {%- endblock %}
+
+      {%- block styles %}
+        <link href="{{ 'css/bootstrap.min.css'|url }}" rel="stylesheet">
+        <link href="{{ 'css/font-awesome.min.css'|url }}" rel="stylesheet">
+        <link href="{{ 'css/base.css'|url }}" rel="stylesheet">
+        {%- if config.theme.highlightjs %}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/{{ config.theme.hljs_style }}.min.css">
+        {%- endif %}
+        {%- for path in extra_css %}
+        <link href="{{ path }}" rel="stylesheet">
+        {%- endfor %}
+      {%- endblock %}
+
+      {%- block libs %}
+
+        <script src="{{ 'js/jquery-1.10.2.min.js'|url }}" defer></script>
+        <script src="{{ 'js/bootstrap.min.js'|url }}" defer></script>
+        {%- if config.theme.highlightjs %}
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js"></script>
+        {%- for lang in config.theme.hljs_languages %}
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/languages/{{lang}}.min.js"></script>
+        {%- endfor %}
+        <script>hljs.initHighlightingOnLoad();</script>
+        {%- endif %}
+      {%- endblock %}
+
+      {%- block analytics %}
+        {%- if config.theme.analytics.gtag %}
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.theme.analytics.gtag }}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', '{{ config.theme.analytics.gtag }}');
+        </script>
+        {%- elif config.google_analytics %}
+        <script>
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+            ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
+            ga('send', 'pageview');
+        </script>
+        {%- endif %}
+      {%- endblock %}
+
+      {%- block extrahead %} {% endblock %}
+    </head>
+
+    <body class="{% if page and page.is_homepage %}homepage {% endif %}{% if config.extra.fork_banner %}has-fork-banner{% endif %}">
+        {%- if config.extra.fork_banner %}
+        <div class="fork-banner">
+          <span class="fork-banner-text">
+            Fork preview &mdash; repo:
+            <a href="{{ config.extra.fork_banner.fork_repo_url }}" target="_blank" rel="noopener">{{ config.extra.fork_banner.fork_repo_label }}</a>
+            &middot; viewing:
+            <a href="{{ config.extra.fork_banner.live_url }}" target="_blank" rel="noopener">{{ config.extra.fork_banner.live_label }}</a>
+            &mdash; Production:
+            <a href="{{ config.extra.fork_banner.prod_site_url }}" target="_blank" rel="noopener">{{ config.extra.fork_banner.prod_site_label }}</a>
+            &middot;
+            <a href="{{ config.extra.fork_banner.prod_repo_url }}" target="_blank" rel="noopener">{{ config.extra.fork_banner.prod_repo_label }}</a>
+          </span>
+        </div>
+        {%- endif %}
+        <div class="navbar fixed-top navbar-expand-lg navbar-{% if config.theme.nav_style == "light" %}light{% else %}dark{% endif %} bg-{{ config.theme.nav_style }}">
+            <div class="container">
+
+                {%- block site_name %}
+                <a class="navbar-brand" href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
+                {%- endblock %}
+
+                {%- if nav|length>1 or (page and (page.next_page or page.previous_page)) or config.repo_url %}
+                <!-- Expander button -->
+                <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar-collapse">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                {%- endif %}
+
+                <!-- Expanded navigation -->
+                <div id="navbar-collapse" class="navbar-collapse collapse">
+                  {%- block site_nav %}
+                    {%- if nav|length>1 %}
+                        <!-- Main navigation -->
+                        <ul class="nav navbar-nav">
+                        {%- for nav_item in nav %}
+                        {%- if nav_item.children %}
+                            <li class="dropdown{% if nav_item.active %} active{% endif %}">
+                                <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
+                                <ul class="dropdown-menu">
+                                {%- for nav_item in nav_item.children %}
+                                    {% include "nav-sub.html" %}
+                                {%- endfor %}
+                                </ul>
+                            </li>
+                        {%- else %}
+                            <li class="navitem{% if nav_item.active %} active{% endif %}">
+                                <a href="{{ nav_item.url|url }}" class="nav-link">{{ nav_item.title }}</a>
+                            </li>
+                        {%- endif %}
+                        {%- endfor %}
+                        </ul>
+                    {%- endif %}
+                  {%- endblock %}
+
+                    <ul class="nav navbar-nav ml-auto">
+                      {%- block search_button %}
+                        {%- if 'search' in config['plugins'] %}
+                        <li class="nav-item">
+                            <a href="#" class="nav-link" data-toggle="modal" data-target="#mkdocs_search_modal">
+                                <i class="fa fa-search"></i> {% trans %}Search{% endtrans %}
+                            </a>
+                        </li>
+                        {%- endif %}
+                      {%- endblock %}
+
+                      {%- block next_prev %}
+                        {%- if page and (page.next_page or page.previous_page) %}
+                            <li class="nav-item">
+                                <a rel="prev" {% if page.previous_page %}href="{{ page.previous_page.url|url }}" class="nav-link"{% else %}class="nav-link disabled"{% endif %}>
+                                    <i class="fa fa-arrow-left"></i> {% trans %}Previous{% endtrans %}
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a rel="next" {% if page.next_page %}href="{{ page.next_page.url|url }}" class="nav-link"{% else %}class="nav-link disabled"{% endif %}>
+                                    {% trans %}Next{% endtrans %} <i class="fa fa-arrow-right"></i>
+                                </a>
+                            </li>
+                        {%- endif %}
+                      {%- endblock %}
+
+                      {%- block repo %}
+                        {%- if page and page.edit_url %}
+                            <li class="nav-item">
+                                <a href="{{ page.edit_url }}" class="nav-link">
+                                    {%- if config.repo_name == 'GitHub' -%}
+                                        <i class="fa fa-github"></i> {% trans repo_name=config.repo_name %}Edit on {{ repo_name }}{% endtrans %}
+                                    {%- elif config.repo_name == 'Bitbucket' -%}
+                                        <i class="fa fa-bitbucket"></i> {% trans repo_name=config.repo_name %}Edit on {{ repo_name }}{% endtrans %}
+                                    {%- elif config.repo_name == 'GitLab' -%}
+                                        <i class="fa fa-gitlab"></i> {% trans repo_name=config.repo_name %}Edit on {{ repo_name }}{% endtrans %}
+                                    {%- elif config.repo_name -%}
+                                        {% trans repo_name=config.repo_name%}Edit on {{ repo_name }}{% endtrans %}
+                                    {% else %}
+                                        {% trans repo_name=config.repo_name%}Edit{% endtrans %}
+                                    {%- endif -%}
+                                </a>
+                            </li>
+                        {%- elif config.repo_url %}
+                            <li class="nav-item">
+                                <a href="{{ config.repo_url }}" class="nav-link">
+                                    {%- if config.repo_name == 'GitHub' -%}
+                                        <i class="fa fa-github"></i> {{ config.repo_name }}
+                                    {%- elif config.repo_name == 'Bitbucket' -%}
+                                        <i class="fa fa-bitbucket"></i> {{ config.repo_name }}
+                                    {%- elif config.repo_name == 'GitLab' -%}
+                                        <i class="fa fa-gitlab"></i> {{ config.repo_name }}
+                                    {%- else -%}
+                                    {{ config.repo_name }}
+                                    {%- endif -%}
+                                </a>
+                            </li>
+                        {%- endif %}
+                      {%- endblock %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="container">
+            <div class="row">
+                {%- block content %}
+                    <div class="col-md-3">{% include "toc.html" %}</div>
+                    <div class="col-md-9" role="main">{% include "content.html" %}</div>
+                {%- endblock %}
+            </div>
+        </div>
+
+        <footer class="col-md-12">
+          {%- block footer %}
+            <hr>
+            {%- if config.copyright %}
+                <p>{{ config.copyright }}</p>
+            {%- endif %}
+            <p>{% trans mkdocs_link='<a href="https://www.mkdocs.org/">MkDocs</a>' %}Documentation built with {{ mkdocs_link }}.{% endtrans %}</p>
+          {%- endblock %}
+        </footer>
+
+      {%- block scripts %}
+        <script>
+            var base_url = {{ base_url | tojson }},
+                shortcuts = {{ config.theme.shortcuts | tojson }};
+        </script>
+        <script src="{{ 'js/base.js'|url }}" defer></script>
+        {%- for path in extra_javascript %}
+        <script src="{{ path }}" defer></script>
+        {%- endfor %}
+      {%- endblock %}
+
+        {% if 'search' in config['plugins'] %}{%- include "search-modal.html" %}{% endif %}
+        {%- include "keyboard-modal.html" %}
+
+    </body>
+</html>
+{% if page and page.is_homepage %}
+<!--
+MkDocs version : {{ mkdocs_version }}
+Build Date UTC : {{ build_date_utc }}
+-->
+{% endif %}

--- a/peeringdb_theme/main.html
+++ b/peeringdb_theme/main.html
@@ -2,6 +2,7 @@
 
 {% block extrahead %}
   <link rel="alternate" type="application/atom+xml" title="PeeringDB Blog" href="{{ base_url }}/blog/atom.xml">
+  <link rel="alternate" type="application/atom+xml" title="PeeringDB Release Notes" href="{{ base_url }}/release_notes/atom.xml">
 {% endblock %}
 
 <!-- Disable next/prev by overriding. -->

--- a/peeringdb_theme/main.html
+++ b/peeringdb_theme/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
-  <link rel="alternate" type="application/atom+xml" title="PeeringDB Blog" href="{{ base_url }}/atom.xml">
+  <link rel="alternate" type="application/atom+xml" title="PeeringDB Blog" href="{{ base_url }}/blog/atom.xml">
 {% endblock %}
 
 <!-- Disable next/prev by overriding. -->

--- a/peeringdb_theme/main.html
+++ b/peeringdb_theme/main.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block extrahead %}
+  <link rel="alternate" type="application/atom+xml" title="PeeringDB Blog" href="{{ base_url }}/atom.xml">
+{% endblock %}
+
 <!-- Disable next/prev by overriding. -->
 {%- block next_prev %}{%- endblock %}
 

--- a/scripts/atom_common.py
+++ b/scripts/atom_common.py
@@ -1,0 +1,77 @@
+"""Shared Atom 1.0 feed-building helpers for this repo's mkdocs hooks."""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from xml.dom import minidom
+from xml.etree import ElementTree as ET
+
+ATOM_NS = "http://www.w3.org/2005/Atom"
+
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_MD_EMPHASIS_RE = re.compile(r"(\*\*|__|\*|_|`)")
+
+
+def plain_text(line: str) -> str:
+    """Strip inline markdown (links, bold/italic/code markers) for feed-reader display."""
+    text = _MD_LINK_RE.sub(r"\1", line)
+    text = _MD_EMPHASIS_RE.sub("", text)
+    return text
+
+
+def truncate(text: str, max_len: int = 280) -> str:
+    if len(text) > max_len:
+        return text[:max_len].rsplit(" ", 1)[0] + "…"
+    return text
+
+
+def isoformat(dt: datetime) -> str:
+    # Dates may carry a real, non-UTC timezone (e.g. git-derived commit times);
+    # normalize to UTC before formatting so the "Z" suffix is always correct.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def dedupe_published(entries: list[dict], key: str = "published", tiebreak_key: str = "path") -> None:
+    """Nudge apart entries sharing an identical published timestamp (e.g. two posts
+    added in the same commit) by 1s increments, so atom:updated stays unique per the
+    W3C Feed Validator's interoperability recommendation. Ties are broken by
+    tiebreak_key for a deterministic, stable ordering across builds."""
+    by_timestamp: dict[datetime, list[dict]] = {}
+    for e in entries:
+        by_timestamp.setdefault(e[key], []).append(e)
+    for group in by_timestamp.values():
+        if len(group) < 2:
+            continue
+        group.sort(key=lambda e: e[tiebreak_key])
+        for offset, e in enumerate(group):
+            e[key] += timedelta(seconds=offset)
+
+
+def build_feed(*, title: str, site_url: str, self_path: str, entries: list[dict]) -> bytes:
+    """entries: dicts with title, entry_url, published (tz-aware datetime), optional summary."""
+    feed = ET.Element("feed", xmlns=ATOM_NS)
+    ET.SubElement(feed, "title").text = title
+    ET.SubElement(feed, "id").text = site_url
+    ET.SubElement(feed, "updated").text = isoformat(
+        entries[0]["published"] if entries else datetime.now(timezone.utc)
+    )
+    ET.SubElement(feed, "link", href=site_url + self_path, rel="self")
+    ET.SubElement(feed, "link", href=site_url)
+    author = ET.SubElement(feed, "author")
+    ET.SubElement(author, "name").text = "PeeringDB"
+
+    for e in entries:
+        entry = ET.SubElement(feed, "entry")
+        ET.SubElement(entry, "title").text = e["title"]
+        ET.SubElement(entry, "id").text = e["entry_url"]
+        ET.SubElement(entry, "link", href=e["entry_url"])
+        ET.SubElement(entry, "published").text = isoformat(e["published"])
+        ET.SubElement(entry, "updated").text = isoformat(e["published"])
+        if e.get("summary"):
+            ET.SubElement(entry, "summary").text = e["summary"]
+
+    return minidom.parseString(ET.tostring(feed, encoding="utf-8")).toprettyxml(
+        indent="  ", encoding="utf-8"
+    )

--- a/scripts/generate_atom_feed.py
+++ b/scripts/generate_atom_feed.py
@@ -1,0 +1,185 @@
+"""mkdocs hook: regenerate docs/atom.xml from docs/blogs.md before every build."""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from xml.dom import minidom
+from xml.etree import ElementTree as ET
+
+log = logging.getLogger("mkdocs.hooks.atom")
+
+ATOM_NS = "http://www.w3.org/2005/Atom"
+ENTRY_RE = re.compile(
+    r"^-\s*\[(?P<title>.+?)\]\((?P<path>blog/[^)]+)\)\s*-\s*(?P<date>\w+ \d{1,2}, \d{4})\s*$"
+)
+MAX_ENTRIES = 20
+
+
+def on_pre_build(config, **kwargs):
+    docs_dir = Path(config["docs_dir"])
+    repo_root = Path(config["config_file_path"]).resolve().parent
+    site_url = os.environ.get("ATOM_SITE_URL") or config.get("site_url") or "https://docs.peeringdb.com/"
+    if not site_url.endswith("/"):
+        site_url += "/"
+
+    entries = []
+    for lineno, line in enumerate(
+        (docs_dir / "blogs.md").read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        stripped = line.strip()
+        if not stripped.startswith("- ["):
+            continue
+        m = ENTRY_RE.match(stripped)
+        if not m:
+            log.warning(f"blogs.md:{lineno}: entry doesn't match expected format, skipping: {stripped!r}")
+            continue
+        entries.append({
+            "title": m.group("title"),
+            "path": m.group("path"),
+            "blogs_md_date": datetime.strptime(m.group("date"), "%B %d, %Y").replace(tzinfo=timezone.utc),
+        })
+
+    bulk_dates = _bulk_first_added_dates(repo_root, "docs/blog/")
+    for e in entries:
+        git_rel = "docs/" + e["path"]
+        published = bulk_dates.get(git_rel)
+        if published is None:
+            published = _first_commit_date_follow(repo_root, git_rel)
+        if published is None:
+            log.warning(f"No git history found for {git_rel}, falling back to blogs.md date")
+            published = e["blogs_md_date"]
+        e["published"] = published
+
+    _dedupe_published(entries)
+
+    entries.sort(key=lambda e: e["published"], reverse=True)
+    entries = entries[:MAX_ENTRIES]
+
+    feed = ET.Element("feed", xmlns=ATOM_NS)
+    ET.SubElement(feed, "title").text = "PeeringDB Blog"
+    ET.SubElement(feed, "id").text = site_url
+    ET.SubElement(feed, "updated").text = _isoformat(
+        entries[0]["published"] if entries else datetime.now(timezone.utc)
+    )
+    ET.SubElement(feed, "link", href=site_url + "atom.xml", rel="self")
+    ET.SubElement(feed, "link", href=site_url)
+    author = ET.SubElement(feed, "author")
+    ET.SubElement(author, "name").text = "PeeringDB"
+
+    for e in entries:
+        entry_url = site_url + e["path"].removesuffix(".md") + "/"
+        entry = ET.SubElement(feed, "entry")
+        ET.SubElement(entry, "title").text = e["title"]
+        ET.SubElement(entry, "id").text = entry_url
+        ET.SubElement(entry, "link", href=entry_url)
+        ET.SubElement(entry, "published").text = _isoformat(e["published"])
+        ET.SubElement(entry, "updated").text = _isoformat(e["published"])
+        summary = _excerpt(docs_dir / e["path"])
+        if summary:
+            ET.SubElement(entry, "summary").text = summary
+
+    pretty = minidom.parseString(ET.tostring(feed, encoding="utf-8")).toprettyxml(
+        indent="  ", encoding="utf-8"
+    )
+    (docs_dir / "atom.xml").write_bytes(pretty)
+    log.info(f"Generated docs/atom.xml with {len(entries)} entries")
+
+
+def _bulk_first_added_dates(repo_root: Path, git_path: str) -> dict[str, datetime]:
+    """One git-log pass over git_path's history; returns {path: earliest 'Added' commit date}.
+
+    Files introduced via a rename (git classifies that transition as R, not A) won't
+    appear here -- callers fall back to a per-file --follow lookup for those.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "log", "--diff-filter=A", "--name-only", "--format=COMMIT|%aI", "--", git_path],
+            cwd=repo_root, capture_output=True, text=True, check=True, timeout=30,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        log.warning(f"git log failed for {git_path}: {exc}")
+        return {}
+
+    first_added: dict[str, str] = {}
+    current_date = None
+    for line in out.splitlines():
+        if line.startswith("COMMIT|"):
+            current_date = line.split("|", 1)[1]
+        elif line.strip():
+            # Newest-first traversal: later (older-commit) lines overwrite, so the
+            # value left after the full pass is each path's *earliest* Added date.
+            first_added[line.strip()] = current_date
+    return {k: datetime.fromisoformat(v) for k, v in first_added.items()}
+
+
+def _first_commit_date_follow(repo_root: Path, git_rel_path: str) -> datetime | None:
+    """Slow but rename-aware: only used as a fallback for files the bulk pass missed."""
+    try:
+        out = subprocess.run(
+            ["git", "log", "--follow", "--format=%aI", "--", git_rel_path],
+            cwd=repo_root, capture_output=True, text=True, check=True, timeout=10,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    lines = [l for l in out.splitlines() if l.strip()]
+    if not lines:
+        return None
+    return datetime.fromisoformat(lines[-1])
+
+
+def _dedupe_published(entries: list[dict]) -> None:
+    """Nudge apart entries sharing an identical published timestamp (e.g. two posts
+    added in the same commit) by 1s increments, so atom:updated stays unique per the
+    W3C Feed Validator's interoperability recommendation. Ties are broken by path for
+    a deterministic, stable ordering across builds."""
+    by_timestamp: dict[datetime, list[dict]] = {}
+    for e in entries:
+        by_timestamp.setdefault(e["published"], []).append(e)
+    for group in by_timestamp.values():
+        if len(group) < 2:
+            continue
+        group.sort(key=lambda e: e["path"])
+        for offset, e in enumerate(group):
+            e["published"] += timedelta(seconds=offset)
+
+
+def _isoformat(dt: datetime) -> str:
+    # git-derived dates carry their real commit timezone (e.g. -07:00); normalize to
+    # UTC before formatting so the "Z" suffix always reflects the correct instant.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_SKIP_LINE_RE = re.compile(r"^(#{1,6}\s|[-*+]\s|\d+\.\s|>|!\[|<!--|```)")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_MD_EMPHASIS_RE = re.compile(r"(\*\*|__|\*|_|`)")
+
+
+def _plain_text(line: str) -> str:
+    """Strip inline markdown (links, bold/italic/code markers) for feed-reader display."""
+    text = _MD_LINK_RE.sub(r"\1", line)
+    text = _MD_EMPHASIS_RE.sub("", text)
+    return text
+
+
+def _excerpt(post_path: Path, max_len: int = 280) -> str:
+    if not post_path.exists():
+        return ""
+    lines = post_path.read_text(encoding="utf-8").splitlines()
+    # line 0 is the H1 title, line 1 is the italic *Month Day, Year* date line.
+    # Skip blank lines and markdown block syntax (headings, lists, images, etc.)
+    # to find the first genuine prose line for the summary.
+    for line in lines[2:]:
+        stripped = line.strip()
+        if not stripped or _SKIP_LINE_RE.match(stripped):
+            continue
+        text = _plain_text(stripped)
+        if len(text) > max_len:
+            text = text[:max_len].rsplit(" ", 1)[0] + "…"
+        return text
+    return ""

--- a/scripts/generate_atom_feed.py
+++ b/scripts/generate_atom_feed.py
@@ -22,7 +22,7 @@ MAX_ENTRIES = 20
 def on_pre_build(config, **kwargs):
     docs_dir = Path(config["docs_dir"])
     repo_root = Path(config["config_file_path"]).resolve().parent
-    site_url = os.environ.get("ATOM_SITE_URL") or config.get("site_url") or "https://docs.peeringdb.com/"
+    site_url = os.environ.get("SITE_URL_OVERRIDE") or config.get("site_url") or "https://docs.peeringdb.com/"
     if not site_url.endswith("/"):
         site_url += "/"
 

--- a/scripts/generate_atom_feed.py
+++ b/scripts/generate_atom_feed.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from xml.dom import minidom
 from xml.etree import ElementTree as ET
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from site_url import resolve_site_url
 
 log = logging.getLogger("mkdocs.hooks.atom")
 
@@ -22,7 +25,7 @@ MAX_ENTRIES = 20
 def on_pre_build(config, **kwargs):
     docs_dir = Path(config["docs_dir"])
     repo_root = Path(config["config_file_path"]).resolve().parent
-    site_url = os.environ.get("SITE_URL_OVERRIDE") or config.get("site_url") or "https://docs.peeringdb.com/"
+    site_url = resolve_site_url(config.get("site_url"))
     if not site_url.endswith("/"):
         site_url += "/"
 

--- a/scripts/generate_banner.py
+++ b/scripts/generate_banner.py
@@ -1,0 +1,49 @@
+"""mkdocs hook: expose fork-preview banner data to templates via config.extra.
+
+On by default (we assume any build without further signal is a dev/fork build).
+Set PROD=TRUE at build time to suppress it. Only a real production deploy
+(which lives outside this repo, in peeringdb/docs) should ever set PROD=TRUE.
+
+Uses on_pre_build rather than on_config: resolve_site_url()'s local-serve
+detection depends on config.site_url already being overwritten with the dev
+server address, which mkdocs's own serve.py only does *after* on_config has
+run (see site_url.py's docstring) but *before* on_pre_build.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from site_url import PROD_SITE_URL, origin_repo_url, resolve_site_url
+
+log = logging.getLogger("mkdocs.hooks.banner")
+
+PROD_REPO_URL = "https://github.com/peeringdb/docs"
+
+
+def on_pre_build(config, **kwargs):
+    if os.environ.get("PROD") == "TRUE":
+        return
+
+    repo_root = Path(config["config_file_path"]).resolve().parent
+    fork_repo_url = origin_repo_url(repo_root)
+    if fork_repo_url is None:
+        log.warning("Could not resolve origin remote; skipping fork-preview banner")
+        return
+
+    live_url = resolve_site_url(config.get("site_url"))
+
+    config["extra"]["fork_banner"] = {
+        "fork_repo_url": fork_repo_url,
+        "fork_repo_label": urlparse(fork_repo_url).path.strip("/"),
+        "live_url": live_url,
+        "live_label": urlparse(live_url).hostname or live_url,
+        "prod_site_url": PROD_SITE_URL,
+        "prod_site_label": urlparse(PROD_SITE_URL).hostname,
+        "prod_repo_url": PROD_REPO_URL,
+        "prod_repo_label": urlparse(PROD_REPO_URL).path.strip("/"),
+    }

--- a/scripts/generate_blog_atom_feed.py
+++ b/scripts/generate_blog_atom_feed.py
@@ -1,21 +1,19 @@
-"""mkdocs hook: regenerate docs/atom.xml from docs/blogs.md before every build."""
+"""mkdocs hook: regenerate docs/blog/atom.xml from docs/blogs.md before every build."""
 from __future__ import annotations
 
 import logging
 import re
 import subprocess
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
-from xml.dom import minidom
-from xml.etree import ElementTree as ET
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from atom_common import build_feed, dedupe_published, plain_text, truncate
 from site_url import resolve_site_url
 
-log = logging.getLogger("mkdocs.hooks.atom")
+log = logging.getLogger("mkdocs.hooks.blog_atom")
 
-ATOM_NS = "http://www.w3.org/2005/Atom"
 ENTRY_RE = re.compile(
     r"^-\s*\[(?P<title>.+?)\]\((?P<path>blog/[^)]+)\)\s*-\s*(?P<date>\w+ \d{1,2}, \d{4})\s*$"
 )
@@ -56,40 +54,22 @@ def on_pre_build(config, **kwargs):
             log.warning(f"No git history found for {git_rel}, falling back to blogs.md date")
             published = e["blogs_md_date"]
         e["published"] = published
+        e["entry_url"] = site_url + e["path"].removesuffix(".md") + "/"
+        e["summary"] = _excerpt(docs_dir / e["path"])
 
-    _dedupe_published(entries)
+    dedupe_published(entries)
 
     entries.sort(key=lambda e: e["published"], reverse=True)
     entries = entries[:MAX_ENTRIES]
 
-    feed = ET.Element("feed", xmlns=ATOM_NS)
-    ET.SubElement(feed, "title").text = "PeeringDB Blog"
-    ET.SubElement(feed, "id").text = site_url
-    ET.SubElement(feed, "updated").text = _isoformat(
-        entries[0]["published"] if entries else datetime.now(timezone.utc)
+    feed_bytes = build_feed(
+        title="PeeringDB Blog",
+        site_url=site_url,
+        self_path="blog/atom.xml",
+        entries=entries,
     )
-    ET.SubElement(feed, "link", href=site_url + "atom.xml", rel="self")
-    ET.SubElement(feed, "link", href=site_url)
-    author = ET.SubElement(feed, "author")
-    ET.SubElement(author, "name").text = "PeeringDB"
-
-    for e in entries:
-        entry_url = site_url + e["path"].removesuffix(".md") + "/"
-        entry = ET.SubElement(feed, "entry")
-        ET.SubElement(entry, "title").text = e["title"]
-        ET.SubElement(entry, "id").text = entry_url
-        ET.SubElement(entry, "link", href=entry_url)
-        ET.SubElement(entry, "published").text = _isoformat(e["published"])
-        ET.SubElement(entry, "updated").text = _isoformat(e["published"])
-        summary = _excerpt(docs_dir / e["path"])
-        if summary:
-            ET.SubElement(entry, "summary").text = summary
-
-    pretty = minidom.parseString(ET.tostring(feed, encoding="utf-8")).toprettyxml(
-        indent="  ", encoding="utf-8"
-    )
-    (docs_dir / "atom.xml").write_bytes(pretty)
-    log.info(f"Generated docs/atom.xml with {len(entries)} entries")
+    (docs_dir / "blog" / "atom.xml").write_bytes(feed_bytes)
+    log.info(f"Generated docs/blog/atom.xml with {len(entries)} entries")
 
 
 def _bulk_first_added_dates(repo_root: Path, git_path: str) -> dict[str, datetime]:
@@ -134,40 +114,7 @@ def _first_commit_date_follow(repo_root: Path, git_rel_path: str) -> datetime | 
     return datetime.fromisoformat(lines[-1])
 
 
-def _dedupe_published(entries: list[dict]) -> None:
-    """Nudge apart entries sharing an identical published timestamp (e.g. two posts
-    added in the same commit) by 1s increments, so atom:updated stays unique per the
-    W3C Feed Validator's interoperability recommendation. Ties are broken by path for
-    a deterministic, stable ordering across builds."""
-    by_timestamp: dict[datetime, list[dict]] = {}
-    for e in entries:
-        by_timestamp.setdefault(e["published"], []).append(e)
-    for group in by_timestamp.values():
-        if len(group) < 2:
-            continue
-        group.sort(key=lambda e: e["path"])
-        for offset, e in enumerate(group):
-            e["published"] += timedelta(seconds=offset)
-
-
-def _isoformat(dt: datetime) -> str:
-    # git-derived dates carry their real commit timezone (e.g. -07:00); normalize to
-    # UTC before formatting so the "Z" suffix always reflects the correct instant.
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
 _SKIP_LINE_RE = re.compile(r"^(#{1,6}\s|[-*+]\s|\d+\.\s|>|!\[|<!--|```)")
-_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
-_MD_EMPHASIS_RE = re.compile(r"(\*\*|__|\*|_|`)")
-
-
-def _plain_text(line: str) -> str:
-    """Strip inline markdown (links, bold/italic/code markers) for feed-reader display."""
-    text = _MD_LINK_RE.sub(r"\1", line)
-    text = _MD_EMPHASIS_RE.sub("", text)
-    return text
 
 
 def _excerpt(post_path: Path, max_len: int = 280) -> str:
@@ -181,8 +128,5 @@ def _excerpt(post_path: Path, max_len: int = 280) -> str:
         stripped = line.strip()
         if not stripped or _SKIP_LINE_RE.match(stripped):
             continue
-        text = _plain_text(stripped)
-        if len(text) > max_len:
-            text = text[:max_len].rsplit(" ", 1)[0] + "…"
-        return text
+        return truncate(plain_text(stripped), max_len)
     return ""

--- a/scripts/generate_cname.py
+++ b/scripts/generate_cname.py
@@ -1,0 +1,24 @@
+"""mkdocs hook: regenerate docs/CNAME before every build.
+
+Derives the GitHub Pages custom domain from SITE_URL_OVERRIDE (if set --
+used by non-production deploys, e.g. this fork's dev preview) or falls
+back to mkdocs.yml's site_url (correct for a real production deploy with
+no override set, so this is safe by default if this branch is ever
+merged upstream -- no manual CNAME edit required).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def on_pre_build(config, **kwargs):
+    docs_dir = Path(config["docs_dir"])
+    site_url = os.environ.get("SITE_URL_OVERRIDE") or config.get("site_url")
+    if not site_url:
+        return
+    domain = urlparse(site_url).hostname
+    if not domain:
+        return
+    (docs_dir / "CNAME").write_text(domain + "\n", encoding="utf-8")

--- a/scripts/generate_cname.py
+++ b/scripts/generate_cname.py
@@ -1,24 +1,23 @@
 """mkdocs hook: regenerate docs/CNAME before every build.
 
-Derives the GitHub Pages custom domain from SITE_URL_OVERRIDE (if set --
-used by non-production deploys, e.g. this fork's dev preview) or falls
-back to mkdocs.yml's site_url (correct for a real production deploy with
-no override set, so this is safe by default if this branch is ever
-merged upstream -- no manual CNAME edit required).
+Domain comes from site_url.resolve_site_url() -- see that module for the
+PROD=TRUE / SITE_URL_OVERRIDE / local-serve precedence.
 """
 from __future__ import annotations
 
-import os
+import sys
 from pathlib import Path
 from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from site_url import LOOPBACK_HOSTS, resolve_site_url
 
 
 def on_pre_build(config, **kwargs):
     docs_dir = Path(config["docs_dir"])
-    site_url = os.environ.get("SITE_URL_OVERRIDE") or config.get("site_url")
-    if not site_url:
-        return
-    domain = urlparse(site_url).hostname
-    if not domain:
+    domain = urlparse(resolve_site_url(config.get("site_url"))).hostname
+    if not domain or domain in LOOPBACK_HOSTS:
+        # A CNAME file only means anything for a real GitHub Pages deploy --
+        # skip it for a local build/serve session.
         return
     (docs_dir / "CNAME").write_text(domain + "\n", encoding="utf-8")

--- a/scripts/generate_release_notes_atom_feed.py
+++ b/scripts/generate_release_notes_atom_feed.py
@@ -1,0 +1,92 @@
+"""mkdocs hook: regenerate docs/release_notes/atom.xml from
+docs/release_notes/index.md before every build."""
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from markdown.extensions.toc import slugify
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from atom_common import build_feed, dedupe_published
+from site_url import resolve_site_url
+
+log = logging.getLogger("mkdocs.hooks.release_notes_atom")
+
+MAX_ENTRIES = 20
+RELEASE_HEADING_RE = re.compile(r"^## Release (?P<version>\d[\w.]*)\s*$")
+DATE_RE = re.compile(r"^(?:Release|Beta Announcement) Date:\s*(?P<date>.+)$")
+DATE_FORMATS = ("%d %b %Y", "%d %B %Y")
+
+
+def _parse_date(text: str) -> datetime | None:
+    for fmt in DATE_FORMATS:
+        try:
+            return datetime.strptime(text.strip(), fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def on_pre_build(config, **kwargs):
+    docs_dir = Path(config["docs_dir"])
+    site_url = resolve_site_url(config.get("site_url"))
+    if not site_url.endswith("/"):
+        site_url += "/"
+
+    index_path = docs_dir / "release_notes" / "index.md"
+    sections: list[dict] = []
+    current = None
+    for line in index_path.read_text(encoding="utf-8").splitlines():
+        heading_m = RELEASE_HEADING_RE.match(line)
+        if heading_m:
+            current = {
+                "version": heading_m.group("version"),
+                "release_date": None,
+                "beta_date": None,
+                "issue_count": 0,
+            }
+            sections.append(current)
+            continue
+        if current is None:
+            continue
+        date_m = DATE_RE.match(line)
+        if date_m:
+            parsed = _parse_date(date_m.group("date"))
+            key = "release_date" if line.startswith("Release Date:") else "beta_date"
+            current[key] = parsed
+            continue
+        if line.strip().startswith("| ["):
+            current["issue_count"] += 1
+
+    entries = []
+    for s in sections:
+        published = s["release_date"] or s["beta_date"]
+        if published is None:
+            log.warning(f"release_notes/index.md: Release {s['version']} has no parseable date, skipping")
+            continue
+        title = f"Release {s['version']}"
+        n = s["issue_count"]
+        entries.append({
+            "title": title,
+            "entry_url": site_url + "release_notes/#" + slugify(title, "-"),
+            "published": published,
+            "summary": f"{n} GitHub issue{'s' if n != 1 else ''} addressed in this release." if n else "",
+            "path": s["version"],  # dedupe_published's tiebreak key
+        })
+
+    dedupe_published(entries)
+    entries.sort(key=lambda e: e["published"], reverse=True)
+    entries = entries[:MAX_ENTRIES]
+
+    feed_bytes = build_feed(
+        title="PeeringDB Release Notes",
+        site_url=site_url,
+        self_path="release_notes/atom.xml",
+        entries=entries,
+    )
+    (docs_dir / "release_notes" / "atom.xml").write_bytes(feed_bytes)
+    log.info(f"Generated docs/release_notes/atom.xml with {len(entries)} entries")

--- a/scripts/site_url.py
+++ b/scripts/site_url.py
@@ -1,0 +1,58 @@
+"""Shared site-URL resolution policy for all mkdocs hooks in this repo.
+
+Precedence:
+1. PROD=TRUE -- real production, full stop.
+2. SITE_URL_OVERRIDE, if set.
+3. The local dev-server address mkdocs itself is serving on (e.g.
+   http://127.0.0.1:8000/), if `mkdocs serve` is what's actually running.
+   Requires callers to be wired to on_pre_build, not on_config: mkdocs's
+   serve.py only overwrites config.site_url with the dev address *after*
+   on_config has already run (see commands/serve.py's `config.site_url =
+   f'http://{config.dev_addr}...'`, right before it calls build()), so
+   on_config never sees it.
+4. LOCAL_SITE_URL ("http://localhost:8000/", mkdocs's own default
+   --dev-addr) -- the fallback when none of the above apply: a plain
+   `mkdocs build` with no env vars and no live dev server, e.g.
+   docs-build-check.yml's CI check or a one-off local build that gets
+   served separately afterward (a static server started after the build
+   already finished can't be predicted at build time -- there's nothing
+   to detect there). Deliberately assumes "local" rather than guessing a
+   real GitHub Pages URL from `git remote get-url origin`: a real checkout
+   always has an `origin` remote, so a git-remote-based guess would almost
+   always "succeed" with a URL that doesn't correspond to anything actually
+   being served, which is more misleading than an honest localhost default.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from urllib.parse import urlparse
+
+PROD_SITE_URL = "https://docs.peeringdb.com/"
+LOCAL_SITE_URL = "http://localhost:8000/"
+LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def resolve_site_url(config_site_url: str | None = None) -> str:
+    if os.environ.get("PROD") == "TRUE":
+        return PROD_SITE_URL
+    override = os.environ.get("SITE_URL_OVERRIDE")
+    if override:
+        return override
+    if config_site_url and urlparse(config_site_url).hostname in LOOPBACK_HOSTS:
+        return config_site_url
+    return LOCAL_SITE_URL
+
+
+def origin_repo_url(repo_root: Path) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=repo_root, capture_output=True, text=True, check=True, timeout=10,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if out.startswith("git@github.com:"):
+        out = "https://github.com/" + out.removeprefix("git@github.com:")
+    return out.removesuffix(".git")


### PR DESCRIPTION
Split out of #449 to make review easier. The content fixes moved to a
separate PR; #448 is the tracking issue for the whole line of work.

This branch started as infra for running a dev/preview fork of this
site, and grew to fix a few problems that showed up while doing that:
preview deploys were indistinguishable from production in a browser,
the two content streams (blog posts and release notes) only had one
combined feed to subscribe to, and `gh-pages` accumulated deploy
history that made no promise about matching the branch that built it.

Opening as draft because part of this (the fork-preview banner) is
fork-specific scaffolding that may not be wanted upstream as-is;
flagging for discussion rather than asking for a merge.

## Changes

- **Fork-preview banner**: shows fork repo URL, current serving URL,
  and where production lives, so a preview deploy is never mistaken
  for the real site. Suppressed via `PROD=TRUE`.
- **Two independent Atom feeds**: `docs/blog/atom.xml` and
  `docs/release_notes/atom.xml`, so blog and release-notes readers can
  subscribe separately. Share a common `scripts/atom_common.py`.
  Release-notes entries are parsed from `release_notes/index.md`'s
  existing `## Release X.Y.Z` sections.
- **Site-URL resolution policy** (`scripts/site_url.py`): one shared
  precedence (`PROD=TRUE` > `SITE_URL_OVERRIDE` > detected local
  dev-server address > `http://localhost:8000/`) used by the banner,
  both feeds, and dynamic `docs/CNAME` generation, so they can't
  disagree about what URL they're building for.
- **gh-pages deploy**: added `--no-history` so every deploy is a
  single fresh commit built from the current branch, instead of
  accumulating commits on top of whatever was already there.

## Testing

- `uv run mkdocs build --strict` -- 0 warnings.
- Feed self-links verified against both `mkdocs serve` and a
  separately-served static build.
- Banner verified visually, including suppression under `PROD=TRUE`.

## Notes for reviewers

`scripts/generate_banner.py` and the `SITE_URL_OVERRIDE` dev-domain
plumbing in `docs-deploy.yml` are the pieces most likely to need
changes, or removal, before this could land on `master` as-is. Happy
to split those out of the eventual mergeable set if preferred.